### PR TITLE
GenStage 0.11.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Honeydew includes a few basic queue modules:
 If you want to implement your own queue, check out the included queues as a guide. Try to keep in mind where exactly your queue state lives, is your queue process(es) where jobs live, or is it a completely stateless connector for some external broker? Or a hybrid? I'm excited to see what you come up with, please open a PR! <3
 
 ### Dispatchers
-By default, Honeydew uses GenStage's [DemandDispatcher](https://hexdocs.pm/gen_stage/Experimental.GenStage.DemandDispatcher.html), but you can use any module that implements the [GenStage.Dispatcher](https://hexdocs.pm/gen_stage/Experimental.GenStage.Dispatcher.html) behaviour. Simply pass the module as the `:dispatcher` option to `Honeydew.queue_spec/2`. I haven't experimented with any other dispatchers aside from the default, if you do, please let me know how it goes.
+By default, Honeydew uses GenStage's [DemandDispatcher](https://hexdocs.pm/gen_stage/GenStage.DemandDispatcher.html), but you can use any module that implements the [GenStage.Dispatcher](https://hexdocs.pm/gen_stage/GenStage.Dispatcher.html) behaviour. Simply pass the module as the `:dispatcher` option to `Honeydew.queue_spec/2`. I haven't experimented with any other dispatchers aside from the default, if you do, please let me know how it goes.
 
 ### Worker State
 Worker state is immutable, the only way to change it is to cause the worker to crash and let the supervisor restart it.
@@ -275,7 +275,7 @@ Your worker module's `init/1` function must return `{:ok, state}`. If anything e
 - statistics?
 - `yield_many/2` support?
 - benchmark mnesia queue's dual filter implementations, discard one?
-- using a global queue, control which node executes a job on-the-fly with a [ParitionDispatcher](https://hexdocs.pm/gen_stage/Experimental.GenStage.PartitionDispatcher.html)?
+- using a global queue, control which node executes a job on-the-fly with a [ParitionDispatcher](https://hexdocs.pm/gen_stage/GenStage.PartitionDispatcher.html)?
 - more tests
 
 ### Acknowledgements

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -1,5 +1,3 @@
-alias Experimental.GenStage
-
 defmodule Honeydew do
   alias Honeydew.Job
   alias Honeydew.Queue

--- a/lib/honeydew/failure_mode/abandon.ex
+++ b/lib/honeydew/failure_mode/abandon.ex
@@ -1,5 +1,3 @@
-alias Experimental.GenStage
-
 defmodule Honeydew.FailureMode.Abandon do
   require Logger
   alias Honeydew.Job

--- a/lib/honeydew/failure_mode/requeue.ex
+++ b/lib/honeydew/failure_mode/requeue.ex
@@ -1,5 +1,3 @@
-alias Experimental.GenStage
-
 defmodule Honeydew.FailureMode.Requeue do
   require Logger
   alias Honeydew.Job

--- a/lib/honeydew/monitor.ex
+++ b/lib/honeydew/monitor.ex
@@ -1,5 +1,3 @@
-alias Experimental.GenStage
-
 defmodule Honeydew.Monitor do
   use GenServer
   require Logger

--- a/lib/honeydew/queue.ex
+++ b/lib/honeydew/queue.ex
@@ -1,5 +1,3 @@
-alias Experimental.GenStage
-
 defmodule Honeydew.Queue do
 
   defmodule State do

--- a/lib/honeydew/worker.ex
+++ b/lib/honeydew/worker.ex
@@ -1,5 +1,3 @@
-alias Experimental.GenStage
-
 defmodule Honeydew.Worker do
   use GenStage
   alias Honeydew.Job

--- a/mix.exs
+++ b/mix.exs
@@ -19,8 +19,7 @@ defmodule Honeydew.Mixfile do
 
   defp deps do
     [
-      {:gen_stage, ">= 0.10.0"},
-
+      {:gen_stage, ">= 0.11.0"},
       {:amqp, ">= 0.1.4", only: :dev},
       {:amqp_client, git: "https://github.com/dsrosario/amqp_client.git", branch: "erlang_otp_19", override: true, only: :dev},
       {:riakc, ">= 2.4.1", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -4,10 +4,10 @@
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "exquisite": {:hex, :exquisite, "0.1.7", "4106503e976f409246731b168cd76eb54262bd04f4facc5cba82c2f53982aaf0", [:mix], []},
-  "gen_stage": {:hex, :gen_stage, "0.10.0", "ce1eb93a3f9708f2e215f70b3d3c7f55dea4a4ed7e9615195e28d543c9086656", [:mix], []},
-  "hamcrest": {:hex, :hamcrest, "0.1.2", "2f06fad05983ce98a7832c4a7a508aab935b68865fdf607d30a030c129ec1365", [], []},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [], []},
-  "protobuffs": {:hex, :protobuffs, "0.8.4", "d38ca5f7380d8477c274680273372011890f8d0037c0d7e7db5c0207b89a4e0b", [], [{:meck, "~> 0.8.4", [hex: :meck, optional: false]}]},
+  "gen_stage": {:hex, :gen_stage, "0.11.0", "943bdfa85c75fa624e0a36a9d135baad20a523be040178f5a215444b45c66ea4", [:mix], []},
+  "hamcrest": {:hex, :hamcrest, "0.1.2", "2f06fad05983ce98a7832c4a7a508aab935b68865fdf607d30a030c129ec1365", [:make, :rebar], []},
+  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
+  "protobuffs": {:hex, :protobuffs, "0.8.4", "d38ca5f7380d8477c274680273372011890f8d0037c0d7e7db5c0207b89a4e0b", [:make, :rebar], [{:meck, "~> 0.8.4", [hex: :meck, optional: false]}]},
   "rabbit_common": {:git, "https://github.com/jbrisbin/rabbit_common.git", "eea16abd375981d16595d2cefaac893c7281187b", [tag: "rabbitmq-3.5.6"]},
-  "riak_pb": {:hex, :riak_pb, "2.1.4", "0de76c3b44a950dc9ffe50f45f7b55128bacce12170705c5e364af95b96a33cf", [], [{:hamcrest, "~> 0.1", [hex: :hamcrest, optional: false]}, {:protobuffs, "~> 0.8", [hex: :protobuffs, optional: false]}]},
-  "riakc": {:hex, :riakc, "2.4.1", "5d2e191ac6597e1a4cfb5628bf78219d126c5ffa42dbb904af622136d8426a32", [], [{:riak_pb, "~> 2.1", [hex: :riak_pb, optional: false]}]}}
+  "riak_pb": {:hex, :riak_pb, "2.1.4", "0de76c3b44a950dc9ffe50f45f7b55128bacce12170705c5e364af95b96a33cf", [:make, :rebar], [{:hamcrest, "~> 0.1", [hex: :hamcrest, optional: false]}, {:protobuffs, "~> 0.8", [hex: :protobuffs, optional: false]}]},
+  "riakc": {:hex, :riakc, "2.4.1", "5d2e191ac6597e1a4cfb5628bf78219d126c5ffa42dbb904af622136d8426a32", [:make, :rebar], [{:riak_pb, "~> 2.1", [hex: :riak_pb, optional: false]}]}}

--- a/test/honeydew/queue_supervisor_test.exs
+++ b/test/honeydew/queue_supervisor_test.exs
@@ -1,5 +1,3 @@
-alias Experimental.GenStage
-
 defmodule Honeydew.QueueSupervisorTest do
   use ExUnit.Case
   alias Honeydew.Queue.ErlangQueue

--- a/test/honeydew_test.exs
+++ b/test/honeydew_test.exs
@@ -19,7 +19,7 @@ defmodule HoneydewTest do
     assert spec == {Honeydew.QueueSupervisor,
                     {Honeydew.QueueSupervisor, :start_link,
                      [queue, Honeydew.Queue.ErlangQueue, [], 1,
-                      Experimental.GenStage.DemandDispatcher, {Honeydew.FailureMode.Abandon, []}]},
+                      GenStage.DemandDispatcher, {Honeydew.FailureMode.Abandon, []}]},
                     :permanent, :infinity, :supervisor, [Honeydew.QueueSupervisor]}
   end
 


### PR DESCRIPTION
I started a dummy project this morning to evaluate honeydew and noticed there was also a GenStage update today that removed the `Experimental` namespace (see [CHANGELOG.md#v0110](https://github.com/elixir-lang/gen_stage/blob/master/CHANGELOG.md#v0110)) which prevented me from from getting it running.

**Changes Made**
- removed all `Experimental` aliases for GenStage from modules
- removed all full namespace references in tests with `Experimental` prefixes for GenStage
- fixed URLs to GenStage documentation in README

**Not Done**
- `test/honeydew/queue/erlang_queue_integration_test.exs:41` is failing, but does not appear to be related to these changes. I will pull another version and pin GenStage to v0.10.0 to verify
- I did not mess with your version number or anything in the mix.exs file for Honeydew. Figured I'd let you handle that if you accept this pull :)