### PR TITLE
Pass supervisor opts

### DIFF
--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -171,7 +171,10 @@ defmodule Honeydew do
         {module, args} -> {module, args}
       end
 
-    supervisor_opts = opts[:supervisor_opts] || [id: {:queue, name}]
+    supervisor_opts =
+      opts
+      |> Keyword.get(:supervisor_opts, [])
+      |> Keyword.put_new(:id, {:queue, name})
 
     Honeydew.create_groups(name)
 
@@ -207,7 +210,11 @@ defmodule Honeydew do
     num = opts[:num] || 10
     init_retry = opts[:init_retry] || 5
     shutdown = opts[:shutdown] || 10_000
-    supervisor_opts = opts[:supervisor_opts] || [id: {:worker, name}]
+
+    supervisor_opts =
+      opts
+      |> Keyword.get(:supervisor_opts, [])
+      |> Keyword.put_new(:id, {:worker, name})
 
     Honeydew.create_groups(name)
 

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -171,7 +171,7 @@ defmodule Honeydew do
         {module, args} -> {module, args}
       end
 
-    supervisor_opts = opts[:supervisor_opts] || []
+    supervisor_opts = opts[:supervisor_opts] || [id: {:queue, name}]
 
     Honeydew.create_groups(name)
 
@@ -207,7 +207,7 @@ defmodule Honeydew do
     num = opts[:num] || 10
     init_retry = opts[:init_retry] || 5
     shutdown = opts[:shutdown] || 10_000
-    supervisor_opts = opts[:supervisor_opts] || []
+    supervisor_opts = opts[:supervisor_opts] || [id: {:worker, name}]
 
     Honeydew.create_groups(name)
 

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -137,9 +137,10 @@ defmodule Honeydew do
   `name` is how you'll refer to the queue to add a task.
 
   You can provide any of the following `opts`:
-  - `queue` is the module that queue will use, you may also provide init/1 args: {module, args}
-  - `dispatcher` the job dispatching strategy, `{module, init_args}`.`
+  - `queue`: is the module that queue will use, you may also provide init/1 args: {module, args}
+  - `dispatcher`: the job dispatching strategy, `{module, init_args}`.`
   - `failure_mode`: the way that failed jobs should be handled. You can pass either a module, or {module, args}, the module must implement the `Honeydew.FailureMode` behaviour. `args` defaults to `[]`.
+  - `supervisor_opts`: options accepted by `Supervisor.Spec.supervisor/3`.
 
   For example:
     `Honeydew.queue_spec("my_awesome_queue")`
@@ -170,9 +171,14 @@ defmodule Honeydew do
         {module, args} -> {module, args}
       end
 
+    supervisor_opts = opts[:supervisor_opts] || []
+
     Honeydew.create_groups(name)
 
-    Supervisor.Spec.supervisor(Honeydew.QueueSupervisor, [name, module, args, num, dispatcher, failure_mode])
+    Supervisor.Spec.supervisor(
+      Honeydew.QueueSupervisor,
+      [name, module, args, num, dispatcher, failure_mode],
+      supervisor_opts)
   end
 
   @doc """
@@ -185,6 +191,7 @@ defmodule Honeydew do
   - `num`: the number of workers to start
   - `init_retry`: the amount of time, in milliseconds, to wait before respawning a worker who's `init/1` function failed
   - `shutdown`: if a worker is in the middle of a job, the amount of time, in milliseconds, to wait before brutally killing it.
+  - `supervisor_opts` options accepted by `Supervisor.Spec.supervisor/3`.
 
   For example:
     `Honeydew.worker_spec("my_awesome_queue", MyJobModule)`
@@ -200,10 +207,14 @@ defmodule Honeydew do
     num = opts[:num] || 10
     init_retry = opts[:init_retry] || 5
     shutdown = opts[:shutdown] || 10_000
+    supervisor_opts = opts[:supervisor_opts] || []
 
     Honeydew.create_groups(name)
 
-    Supervisor.Spec.supervisor(Honeydew.WorkerSupervisor, [name, module, args, num, init_retry, shutdown])
+    Supervisor.Spec.supervisor(
+      Honeydew.WorkerSupervisor,
+      [name, module, args, num, init_retry, shutdown],
+      supervisor_opts)
   end
 
   @groups [:workers,

--- a/test/honeydew_test.exs
+++ b/test/honeydew_test.exs
@@ -23,7 +23,7 @@ defmodule HoneydewTest do
     queue = :erlang.unique_integer
     spec =  Honeydew.queue_spec(queue)
 
-    assert spec == {Honeydew.QueueSupervisor,
+    assert spec == {{:queue, queue},
                     {Honeydew.QueueSupervisor, :start_link,
                      [queue, Honeydew.Queue.ErlangQueue, [], 1,
                       {Honeydew.Dispatcher.LRU, []}, {Honeydew.FailureMode.Abandon, []}]},
@@ -32,7 +32,7 @@ defmodule HoneydewTest do
     queue = {:global, :erlang.unique_integer}
     spec =  Honeydew.queue_spec(queue)
 
-    assert spec == {Honeydew.QueueSupervisor,
+    assert spec == {{:queue, queue},
                     {Honeydew.QueueSupervisor, :start_link,
                      [queue, Honeydew.Queue.ErlangQueue, [], 1,
                       {Honeydew.Dispatcher.LRUNode, []}, {Honeydew.FailureMode.Abandon, []}]},
@@ -59,7 +59,7 @@ defmodule HoneydewTest do
     queue = :erlang.unique_integer
 
     spec =  Honeydew.worker_spec(queue, Worker)
-    assert spec == {Honeydew.WorkerSupervisor,
+    assert spec == {{:worker, queue},
                     {Honeydew.WorkerSupervisor, :start_link,
                      [queue, Worker, [], 10, 5, 10000]}, :permanent, :infinity,
                     :supervisor, [Honeydew.WorkerSupervisor]}

--- a/test/honeydew_test.exs
+++ b/test/honeydew_test.exs
@@ -4,8 +4,15 @@ defmodule HoneydewTest do
   test "queue_spec/2" do
     queue = :erlang.unique_integer
 
-    spec =  Honeydew.queue_spec(queue, queue: {:abc, [1,2,3]}, dispatcher: {Dis.Patcher, [:a, :b]}, failure_mode: {Fail.Ure, [:a, :b]})
-    assert spec == {Honeydew.QueueSupervisor,
+    spec =
+      Honeydew.queue_spec(
+        queue,
+        queue: {:abc, [1,2,3]},
+        dispatcher: {Dis.Patcher, [:a, :b]},
+        failure_mode: {Fail.Ure, [:a, :b]},
+        supervisor_opts: [id: :my_queue_supervisor])
+
+    assert spec == {:my_queue_supervisor,
                     {Honeydew.QueueSupervisor, :start_link,
                      [queue, :abc, [1, 2, 3], 1, {Dis.Patcher, [:a, :b]},
                       {Fail.Ure, [:a, :b]}]}, :permanent, :infinity, :supervisor,
@@ -35,8 +42,14 @@ defmodule HoneydewTest do
   test "worker_spec/2" do
     queue = :erlang.unique_integer
 
-    spec = Honeydew.worker_spec(queue, {Worker, [1, 2, 3]}, num: 123, init_retry_secs: 5)
-    assert spec == {Honeydew.WorkerSupervisor,
+    spec = Honeydew.worker_spec(
+      queue,
+      {Worker, [1, 2, 3]},
+      num: 123,
+      init_retry_secs: 5,
+      supervisor_opts: [id: :my_worker_supervisor])
+
+    assert spec == {:my_worker_supervisor,
                     {Honeydew.WorkerSupervisor, :start_link,
                      [queue, Worker, [1, 2, 3], 123, 5, 10_000]}, :permanent,
                     :infinity, :supervisor, [Honeydew.WorkerSupervisor]}


### PR DESCRIPTION
This allows passing options to `Supervisor.Spec.supervisor/3` when defining queue and worker supervisors with `queue_spec/2` and `worker_spec/2`.

A use case of when it's needed is specifying supervisor ids when defining multiple queues in the same application like this:

```elixir
defmodule QueueApp do
  def start do
    nodes = [node()]

    children = [
      Honeydew.queue_spec({:global, :first_queue}, queue: {Honeydew.Queue.Mnesia, [nodes, [disc_copies: nodes], []]}),
      Honeydew.queue_spec({:global, :second_queue}, queue: {Honeydew.Queue.Mnesia, [nodes, [disc_copies: nodes], []]}),
    ]

    Supervisor.start_link(children, strategy: :one_for_one)
  end
end

QueueApp.start
```

which currently fails with:

```
** (ArgumentError) duplicated id Honeydew.QueueSupervisor found in the supervisor specification, please explicitly pass the :id option when defining this worker/supervisor
    (elixir) lib/supervisor/spec.ex:175: Supervisor.Spec.assert_unique_ids/1
    (elixir) lib/supervisor/spec.ex:169: Supervisor.Spec.supervise/2
    (elixir) lib/supervisor.ex:297: Supervisor.start_link/2
```

With this PR it's possible to specify the required option:

```elixir
Honeydew.queue_spec(
  {:global, :first_queue},
  queue: {Honeydew.Queue.Mnesia, [nodes, [disc_copies: nodes], []]},
  supervisor_opts: [id: :first_queue_supervisor]),
```