### PR TITLE
Fix compilation warnings

### DIFF
--- a/lib/honeydew/success_mode/log.ex
+++ b/lib/honeydew/success_mode/log.ex
@@ -4,8 +4,10 @@ defmodule Honeydew.SuccessMode.Log do
   @behaviour Honeydew.SuccessMode
 
   def handle_success(%Job{enqueued_at: enqueued_at, started_at: started_at, completed_at: completed_at} = job, []) do
-    queue_time = started_at - enqueued_at
-    run_time = completed_at - started_at
-    Logger.info "Job #{inspect job} completed, sat in queue for #{queue_time}ms, and took #{run_time}ms to complete."
+    Logger.info fn ->
+      queue_time = started_at - enqueued_at
+      run_time = completed_at - started_at
+      "Job #{inspect job} completed, sat in queue for #{queue_time}ms, and took #{run_time}ms to complete."
+    end
   end
 end


### PR DESCRIPTION
TravisCi is reporting the following compilation warnings when compiling the app in the test environment.

```
warning: the result of the expression is ignored (suppress the warning
by assigning the expression to the _ variable)
  lib/honeydew/success_mode/log.ex:7

warning: the result of the expression is ignored (suppress the warning
by assigning the expression to the _ variable)
  lib/honeydew/success_mode/log.ex:8
```

This is because we are purging all log statements lower than warning in the test environment.

```elixir
config :logger
  compile_time_purge_level: :warn
```

This change puts both the calculations and text for the log message into a function so they can all be purged together and not cause compilation warnings.