### PR TITLE
Support for elixir 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ elixir:
   - 1.4.5
   - 1.5.1
 otp_release:
+  - 19.1
   - 19.3
   - 20.0
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: elixir
 elixir:
-  - 1.4.2
+  - 1.4.5
+  - 1.5.1
 otp_release:
   - 19.3
+  - 20.0
 cache:
   directories:
     - _build

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Honeydew.Mixfile do
   def project do
     [app: :honeydew,
      version: @version,
-     elixir: "~> 1.4.0",
+     elixir: "~> 1.4",
      docs: docs(),
      deps: deps(),
      package: package(),


### PR DESCRIPTION
This relaxes the mix.exs constraint to allow for elixir 1.4 and 1.5. It also tests against Elixir 1.4.5, 1.5.1 and OTP 19.1, 19.3, 20.0.