### PR TITLE
Add Honeydew.Worker behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ defmodule Riak do
     `{:riakc, ">= 2.4.1}`
   """
 
+  @behaviour Honeydew.Worker
+
   def init([ip, port]) do
     :riakc_pb_socket.start_link(ip, port) # returns {:ok, riak}
   end
@@ -161,6 +163,7 @@ iex(queue@dax)1> QueueApp.start
 And we'll run our workers on `background@dax` with:
 ```elixir
 defmodule HeavyTask do
+  @behaviour Honeydew.Worker
 
   # note that in this case, our worker is stateless, so we left out `init/1`
 

--- a/examples/distributed.exs
+++ b/examples/distributed.exs
@@ -1,4 +1,6 @@
 defmodule HeavyTask do
+  @behaviour Honeydew.Worker
+
   def work_really_hard(secs) do
     :timer.sleep(1_000 * secs)
     IO.puts "I worked really hard for #{secs} secs!"

--- a/examples/riak.exs
+++ b/examples/riak.exs
@@ -5,6 +5,8 @@ defmodule Riak do
     `{:riakc, ">= 2.4.1}`
   """
 
+  @behaviour Honeydew.Worker
+
   def init([ip, port]) do
     :riakc_pb_socket.start_link(ip, port) # returns {:ok, riak}
   end

--- a/examples/simple.exs
+++ b/examples/simple.exs
@@ -5,6 +5,8 @@
 defmodule HeavyTask do
   use Honeydew.Progress
 
+  @behaviour Honeydew.Worker
+
   def work_really_hard(secs) do
     Enum.each 0..secs, fn i ->
       Process.sleep(1_000)

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -142,8 +142,8 @@ defmodule Honeydew do
   @type queue_spec_opt ::
     {:queue, mod_or_mod_args} |
     {:dispatcher, mod_or_mod_args} |
-    {:failure_mode, mod_or_mod_args} |
-    {:success_mode, mod_or_mod_args} |
+    {:failure_mode, mod_or_mod_args | nil} |
+    {:success_mode, mod_or_mod_args | nil} |
     {:supervisor_opts, supervisor_opts}
 
   @doc """
@@ -159,12 +159,13 @@ defmodule Honeydew do
   - `dispatcher`: the job dispatching strategy, `{module, init_args}`.
 
   - `failure_mode`: the way that failed jobs should be handled. You can pass
-    either a module, or {module, args}, the module must implement the
-    `Honeydew.FailureMode` behaviour. `args` defaults to `[]`.
+    either a module, or `{module, args}`. The module must implement the
+    `Honeydew.FailureMode` behaviour. Defaults to
+    `{Honeydew.FailureMode.Abandon, []}`.
 
   - `success_mode`: a callback that runs when a job successfully completes. You
-     can pass either a module, or {module, args}, the module must implement the
-     `Honeydew.SuccessMode` behaviour, `args` defaults to `[]`.
+     can pass either a module, or `{module, args}`. The module must implement
+     the `Honeydew.SuccessMode` behaviour. Defaults to `nil`.
 
   - `supervisor_opts`: options accepted by `Supervisor.Spec.supervisor/3`.
 
@@ -231,15 +232,15 @@ defmodule Honeydew do
 
   `queue` is the name of the queue that the workers pull jobs from.
 
-  `module` is the module that the workers in your queue will use, you may also
+  `module` is the module that the workers in your queue will usei. You may also
   provide `c:Honeydew.Worker.init/1` args with `{module, args}`.
 
   You can provide any of the following `opts`:
 
   - `num`: the number of workers to start. Defaults to `10`.
 
-  - `init_retry`: the amount of time, in milliseconds, to wait before respawning
-     a worker who's `init/1` function failed. Defaults to `5`.
+  - `init_retry`: the amount of time, in seconds, to wait before respawning
+     a worker whose `c:Honeydew.Worker.init/1` function failed. Defaults to `5`.
 
   - `shutdown`: if a worker is in the middle of a job, the amount of time, in
      milliseconds, to wait before brutally killing it. Defaults to `10_000`.

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -152,14 +152,26 @@ defmodule Honeydew do
   `name` is how you'll refer to the queue to add a task.
 
   You can provide any of the following `opts`:
-  - `queue`: is the module that queue will use, you may also provide init/1 args: {module, args}
+
+  - `queue`: is the module that queue will use, you may also provide `init/1`
+    args: `{module, args}`
+
   - `dispatcher`: the job dispatching strategy, `{module, init_args}`.
-  - `failure_mode`: the way that failed jobs should be handled. You can pass either a module, or {module, args}, the module must implement the `Honeydew.FailureMode` behaviour. `args` defaults to `[]`.
-  - `success_mode`: a callback that runs when a job successfully completes. You can pass either a module, or {module, args}, the module must implement the `Honeydew.SuccessMode` behaviour, `args` defaults to `[]`.
+
+  - `failure_mode`: the way that failed jobs should be handled. You can pass
+    either a module, or {module, args}, the module must implement the
+    `Honeydew.FailureMode` behaviour. `args` defaults to `[]`.
+
+  - `success_mode`: a callback that runs when a job successfully completes. You
+     can pass either a module, or {module, args}, the module must implement the
+     `Honeydew.SuccessMode` behaviour, `args` defaults to `[]`.
+
   - `supervisor_opts`: options accepted by `Supervisor.Spec.supervisor/3`.
 
   For example:
+
   - `Honeydew.queue_spec("my_awesome_queue")`
+
   - `Honeydew.queue_spec("my_awesome_queue", queue: {MyQueueModule, [ip: "localhost"]}, dispatcher: {Honeydew.Dispatcher.MRU, []})`
   """
   @spec queue_spec(queue_name, [queue_spec_opt]) :: Supervisor.Spec.spec
@@ -217,19 +229,32 @@ defmodule Honeydew do
   @doc """
   Creates a supervision spec for workers.
 
-  `queue` is the name of the queue that the workers pull jobs from
-  `module` is the module that the workers in your queue will use, you may also provide init/1 args: {module, args}
+  `queue` is the name of the queue that the workers pull jobs from.
+
+  `module` is the module that the workers in your queue will use, you may also
+  provide `c:Honeydew.Worker.init/1` args with `{module, args}`.
 
   You can provide any of the following `opts`:
-  - `num`: the number of workers to start
-  - `init_retry`: the amount of time, in milliseconds, to wait before respawning a worker who's `init/1` function failed
-  - `shutdown`: if a worker is in the middle of a job, the amount of time, in milliseconds, to wait before brutally killing it.
+
+  - `num`: the number of workers to start. Defaults to `10`.
+
+  - `init_retry`: the amount of time, in milliseconds, to wait before respawning
+     a worker who's `init/1` function failed. Defaults to `5`.
+
+  - `shutdown`: if a worker is in the middle of a job, the amount of time, in
+     milliseconds, to wait before brutally killing it. Defaults to `10_000`.
+
   - `supervisor_opts` options accepted by `Supervisor.Spec.supervisor/3`.
-  - `nodes`: for :global queues, you can provide a list of nodes to stay connected to (your queue node and enqueuing nodes)
+
+  - `nodes`: for :global queues, you can provide a list of nodes to stay
+     connected to (your queue node and enqueuing nodes). Defaults to `[]`.
 
   For example:
+
   - `Honeydew.worker_spec("my_awesome_queue", MyJobModule)`
+
   - `Honeydew.worker_spec("my_awesome_queue", {MyJobModule, [key: "secret key"]}, num: 3)`
+
   - `Honeydew.worker_spec({:global, "my_awesome_queue"}, MyJobModule, nodes: [:clientfacing@dax, :queue@dax])`
   """
   @spec worker_spec(queue_name, mod_or_mod_args, [worker_spec_opt])

--- a/lib/honeydew/worker.ex
+++ b/lib/honeydew/worker.ex
@@ -4,10 +4,17 @@ defmodule Honeydew.Worker do
   require Honeydew
   alias Honeydew.Job
 
+  @doc """
+  Invoked when the worker starts up for the first time.
+  """
+  @callback init(args :: term) :: {:ok, state :: term}
+  @optional_callbacks init: 1
+
   defmodule State do
     defstruct [:queue, :module, :user_state]
   end
 
+  @doc false
   def start_link(queue, module, args, init_retry_secs) do
     GenServer.start_link(__MODULE__, [queue, module, args, init_retry_secs])
   end
@@ -34,6 +41,7 @@ defmodule Honeydew.Worker do
        end
   end
 
+  @doc false
   def worker_init(true, args, %State{module: module} = state) do
     try do
       case apply(module, :init, [args]) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 defmodule Stateless do
+  @behaviour Honeydew.Worker
   use Honeydew.Progress
 
   def send_msg(to, msg) do
@@ -25,6 +26,7 @@ defmodule Stateless do
 end
 
 defmodule Stateful do
+  @behaviour Honeydew.Worker
   def init(state) do
     {:ok, state}
   end


### PR DESCRIPTION
This adds a Honeydew.Worker behaviour which defines an optional init/1 callback. This helps the user to find out if they are returning an invalid value from the init/1 callback.

I also updated the Honeydew.worker_spec documentation to include default values and improve formatting.