### PR TITLE
Update typespec so args is a term instead of list

### DIFF
--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -2,7 +2,7 @@ defmodule Honeydew do
   alias Honeydew.Job
   require Logger
 
-  @type mod_or_mod_args :: module | {module, list}
+  @type mod_or_mod_args :: module | {module, args :: term}
   @type queue_name :: String.t | atom | {:global, String.t | atom}
   @type supervisor_opts :: Keyword.t
 


### PR DESCRIPTION
Since `Honeydew.worker_spec/3` passes the args from the `module_and_args` param directly to the Honeydew.Worker.init/1 callback, there is no reason why the arguments here have to be a list. After double-checking the args param for `GenServer.start_link/3` and the associated
`GenServer.init/1` callback, it appears common for the `args` param to be a term instead of a list.