### PR TITLE
Add version badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Honeydew 💪🏻🍈 [![Build Status](https://travis-ci.org/koudelka/honeydew.svg?branch=master)](https://travis-ci.org/koudelka/honeydew)
+Honeydew 💪🏻🍈
 ========
+[![Build Status](https://travis-ci.org/koudelka/honeydew.svg?branch=master)](https://travis-ci.org/koudelka/honeydew)
+[![Hex pm](https://img.shields.io/hexpm/v/honeydew.svg?style=flat)](https://hex.pm/packages/honeydew)
 
 Honeydew (["Honey, do!"](http://en.wiktionary.org/wiki/honey_do_list)) is a pluggable job queue + worker pool for Elixir.
 


### PR DESCRIPTION
Because the more badges you have, the cooler your project is. 😎 

But seriously, it would be nice to pull up the readme and see the current version without having to scroll.