### PR TITLE
Add basic queue docs

### DIFF
--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -153,9 +153,10 @@ defmodule Honeydew do
 
   You can provide any of the following `opts`:
 
-  - `queue`: is the module that queue will use, you may also provide `init/1`
-    args: `{module, args}`
-
+  - `queue`: is the module that queue will use. Defaults to
+    `Honeydew.Queue.ErlangQueue`. You may also provide args to the queue's
+    `c:Honeydew.Queue.init/2` callback using the following format:
+    `{module, args}`.
   - `dispatcher`: the job dispatching strategy, `{module, init_args}`.
 
   - `failure_mode`: the way that failed jobs should be handled. You can pass
@@ -232,7 +233,7 @@ defmodule Honeydew do
 
   `queue` is the name of the queue that the workers pull jobs from.
 
-  `module` is the module that the workers in your queue will usei. You may also
+  `module` is the module that the workers in your queue will use. You may also
   provide `c:Honeydew.Worker.init/1` args with `{module, args}`.
 
   You can provide any of the following `opts`:

--- a/lib/honeydew/queue.ex
+++ b/lib/honeydew/queue.ex
@@ -19,7 +19,7 @@ defmodule Honeydew.Queue do
   @type name :: term | {:global, term} # tighten this to a string or atom?
   @type job :: %Honeydew.Job{}
 
-  @callback init(name, term) :: {:ok, private}
+  @callback init(name, arg :: term) :: {:ok, private}
   @callback enqueue(job, private) :: {private, job}
   @callback reserve(private) :: {private, job}
   @callback ack(job, private) :: private

--- a/lib/honeydew/queue/erlang_queue.ex
+++ b/lib/honeydew/queue/erlang_queue.ex
@@ -1,4 +1,11 @@
 defmodule Honeydew.Queue.ErlangQueue do
+  @moduledoc """
+  An in-memory queue implementation.
+
+  This is a simple FIFO queue implemented with the `:queue` and `Map` modules.
+
+  Started with `Honeydew.queue_spec/2`.
+  """
   require Logger
   alias Honeydew.Job
 

--- a/lib/honeydew/queue/mnesia.ex
+++ b/lib/honeydew/queue/mnesia.ex
@@ -1,4 +1,15 @@
 defmodule Honeydew.Queue.Mnesia do
+  @moduledoc """
+  A mnesia-based queue implementation.
+
+  This queue is configurable in all the ways mnesia is. For example, you can:
+
+  * Run with replication (with queues running on multiple nodes)
+  * Persist jobs to disk (dets)
+  * Follow various safety modes ("access contexts")
+
+  Started with `Honeydew.queue_spec/2`.
+  """
   require Honeydew.Job
   require Logger
   alias Honeydew.Job
@@ -7,6 +18,7 @@ defmodule Honeydew.Queue.Mnesia do
 
   # private queue state
   defmodule PState do
+    @moduledoc false
     defstruct [:table, :access_context]
   end
 


### PR DESCRIPTION
I was setting up a new queue, and found the docs could use a little more info. This adds a high level explanation for each queue module, as well as referencing the default `ErlangQueue` from `Honeydew.queue_spec/2`.