### PR TITLE
Propagate error upward if unable to start worker

### DIFF
--- a/lib/honeydew/worker_supervisor.ex
+++ b/lib/honeydew/worker_supervisor.ex
@@ -4,24 +4,15 @@ defmodule Honeydew.WorkerSupervisor do
   def start_link(queue, module, args, num_workers, init_retry_secs, shutdown) do
     import Supervisor.Spec
 
-    children = [worker(Worker, [queue, module, args, init_retry_secs], restart: :transient, shutdown: shutdown)]
+    children = Enum.map(1..num_workers, fn n ->
+      worker(Worker,[queue, module, args, init_retry_secs], id: "#{module}##{n}", restart: :transient, shutdown: shutdown)
+    end)
 
-    opts = [strategy: :simple_one_for_one,
+    opts = [strategy: :one_for_one,
             name: Honeydew.supervisor(queue, :worker),
             max_restarts: num_workers,
             max_seconds: init_retry_secs]
 
-    {:ok, supervisor} = Supervisor.start_link(children, opts)
-
-    start_children(supervisor, num_workers)
-
-    {:ok, supervisor}
+    Supervisor.start_link(children, opts)
   end
-
-  defp start_children(_supervisor, 0), do: :noop
-  defp start_children(supervisor, num) do
-    Supervisor.start_child(supervisor, [])
-    start_children(supervisor, num-1)
-  end
-
 end

--- a/test/honeydew/worker_supervisor_test.exs
+++ b/test/honeydew/worker_supervisor_test.exs
@@ -1,22 +1,30 @@
 defmodule Honeydew.WorkerSupervisorTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
+  alias Honeydew.WorkerSupervisor
 
   setup do
     pool = :erlang.unique_integer
-
     Honeydew.create_groups(pool)
 
-    {:ok, supervisor} = Honeydew.WorkerSupervisor.start_link(pool, Stateful, [:state_here], 7, 5, 10_000)
+    on_exit fn ->
+      Honeydew.delete_groups(pool)
+    end
 
-    # on_exit fn ->
-    #   Supervisor.stop(supervisor)
-    #   Honeydew.delete_groups(pool)
-    # end
-
-    [supervisor: supervisor]
+    [pool: pool]
   end
 
-  test "starts the correct number of workers", %{supervisor: supervisor} do
+  test "starts the correct number of workers", %{pool: pool} do
+    {:ok, supervisor} =
+      WorkerSupervisor.start_link(pool, Stateful, [:state_here], 7, 5, 10_000)
+
     assert supervisor |> Supervisor.which_children |> Enum.count == 7
+  end
+
+  test "crashes when the worker module does not exist", %{pool: pool} do
+    Process.flag(:trap_exit, true)
+
+    assert {:error, {:shutdown, {:failed_to_start_child, _, _}}} =
+      WorkerSupervisor.start_link(pool, DoesNotExist, [], 7, 5, 10_000)
   end
 end

--- a/test/honeydew_test.exs
+++ b/test/honeydew_test.exs
@@ -67,6 +67,16 @@ defmodule HoneydewTest do
                     :supervisor, [Honeydew.WorkerGroupSupervisor]}
   end
 
+  test "worker_spec/2 with a module that doesn't exist" do
+    queue = :erlang.unique_integer
+    Process.flag(:trap_exit, true)
+
+    assert {:error, {:shutdown, {:failed_to_start_child, _, _}}} =
+      Supervisor.start_link([
+        Honeydew.worker_spec(queue, DoesNotExist)
+      ], strategy: :one_for_one)
+  end
+
   test "group/1" do
     assert Honeydew.group(:my_queue, :workers) == :"honeydew.workers.my_queue"
   end


### PR DESCRIPTION
I was having an issue where if I typo-ed my worker module name, so I'd have a worker pool start up, but with no workers. Since the number of workers aren't changing at runtime, I found I could just create one child in the `WorkerSupervisor` for each child, and not have to use a separate start_child function to get everything started. Since we're now using a `:one_for_one` strategy, it makes it easy for `WorkerSupervisor.start_link` to return a standard `:failure_to_start_child` error tuple.

If you're not a fan of the migration from `:simple_one_for_one` to `:one_for_one`, I'd be happy to change it back. Regardless, I think the tests are useful.