### PR TITLE
Prefer :capture_log tag when log data not tested

### DIFF
--- a/test/honeydew/failure_mode/move_test.exs
+++ b/test/honeydew/failure_mode/move_test.exs
@@ -1,6 +1,7 @@
 defmodule Honeydew.FailureMode.MoveTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
+
+  @moduletag :capture_log
 
   setup do
     queue = :erlang.unique_integer
@@ -25,29 +26,25 @@ defmodule Honeydew.FailureMode.MoveTest do
   end
 
   test "should move the job on the new queue", %{queue: queue, failure_queue: failure_queue} do
-    capture_log(fn ->
-      {:crash, [self()]} |> Honeydew.async(queue)
-      assert_receive :job_ran
+    {:crash, [self()]} |> Honeydew.async(queue)
+    assert_receive :job_ran
 
-      Process.sleep(500) # let the failure mode do its thing
+    Process.sleep(500) # let the failure mode do its thing
 
-      assert Honeydew.status(queue) |> get_in([:queue, :count]) == 0
-      refute_receive :job_ran
+    assert Honeydew.status(queue) |> get_in([:queue, :count]) == 0
+    refute_receive :job_ran
 
-      assert Honeydew.status(failure_queue) |> get_in([:queue, :count]) == 1
-    end)
+    assert Honeydew.status(failure_queue) |> get_in([:queue, :count]) == 1
   end
 
   test "should inform the awaiting process of the error", %{queue: queue, failure_queue: failure_queue} do
-    capture_log(fn ->
-      job = {:crash, [self()]} |> Honeydew.async(queue, reply: true)
+    job = {:crash, [self()]} |> Honeydew.async(queue, reply: true)
 
-      assert {:moved, {%RuntimeError{message: "ignore this crash"}, _stacktrace}} = Honeydew.yield(job)
+    assert {:moved, {%RuntimeError{message: "ignore this crash"}, _stacktrace}} = Honeydew.yield(job)
 
-      {:ok, _} = Helper.start_worker_link(failure_queue, Stateless)
+    {:ok, _} = Helper.start_worker_link(failure_queue, Stateless)
 
-      # job ran in the failure queue
-      assert {:error, {%RuntimeError{message: "ignore this crash"}, _stacktrace}} = Honeydew.yield(job)
-    end)
+    # job ran in the failure queue
+    assert {:error, {%RuntimeError{message: "ignore this crash"}, _stacktrace}} = Honeydew.yield(job)
   end
 end

--- a/test/honeydew/queue/mnesia_queue_integration_test.exs
+++ b/test/honeydew/queue/mnesia_queue_integration_test.exs
@@ -1,7 +1,8 @@
 defmodule Honeydew.MnesiaQueueIntegrationTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
   alias Honeydew.Job
+
+  @moduletag :capture_log
 
   @num_workers 5
 
@@ -166,13 +167,11 @@ defmodule Honeydew.MnesiaQueueIntegrationTest do
 
     Process.exit(worker_sup, :kill)
 
-    capture_log(fn ->
-      workers
-      |> Map.keys
-      |> Enum.each(fn worker ->
-        Process.exit(worker, :kill)
-        assert not Process.alive?(worker)
-      end)
+    workers
+    |> Map.keys
+    |> Enum.each(fn worker ->
+      Process.exit(worker, :kill)
+      assert not Process.alive?(worker)
     end)
 
     Process.flag(:trap_exit, false)


### PR DESCRIPTION
Since we are only using capture_log to silence the error output in the tests, it seems like it is less intrusive to use the `:capture_log` tag instead of wrapping everything in a function call. If a test fails
that's tagged with `:capture_log`, it will automatically dump all log output to the console.