### PR TITLE
New workers shouldn't get jobs from suspended queues

### DIFF
--- a/lib/honeydew/queue.ex
+++ b/lib/honeydew/queue.ex
@@ -137,11 +137,6 @@ defmodule Honeydew.Queue do
   # Enqueue
   #
 
-  def handle_call({:enqueue, job}, _from, %State{suspended: true} = state) do
-    {private, job} = do_enqueue(job, state)
-    {:reply, {:ok, job}, %{state | private: private}}
-  end
-
   def handle_call({:enqueue, job}, _from, state) do
     {private, job} = do_enqueue(job, state)
     state = %{state | private: private} |> dispatch
@@ -245,6 +240,7 @@ defmodule Honeydew.Queue do
     %{state | monitors: MapSet.put(monitors, monitor)}
   end
 
+  defp dispatch(%State{suspended: true} = state), do: state
   defp dispatch(%State{module: module, private: private} = state) do
     with true <- worker_available?(state),
           {private, job} <- module.reserve(private),


### PR DESCRIPTION
There is an issue where if new workers were added to a queue, they would start processing jobs, even if the queue is suspended. This moves the suspended check from Queue.enqueue to Queue.dispatch, giving us a single place to handle suspended queues.

While I was in there, I removed commented-out calls to non-existent resume and suspend functions.