### PR TITLE
Add docs for async, yield, and filter

### DIFF
--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -25,7 +25,7 @@ defmodule Honeydew do
   @doc """
   Runs a task asynchronously.
 
-  Raises an `ArgumentError` if the queue process is not available.
+  Raises a `RuntimeError` if `queue` process is not available.
 
   ## Examples
 

--- a/lib/honeydew/job.ex
+++ b/lib/honeydew/job.ex
@@ -1,4 +1,7 @@
 defmodule Honeydew.Job do
+  @moduledoc """
+  A Honeydew job.
+  """
   require Record
 
   # :private needs to be first, the mnesia queue's ordering depends on it
@@ -17,34 +20,47 @@ defmodule Honeydew.Job do
   @kv Enum.map(@fields, &{&1, nil})
 
   defstruct @kv
+  @doc false
   Record.defrecord :job, @kv
   @match_spec @fields |> Enum.map(&{&1, :_}) |> Enum.into(%{})
 
+  @type t :: %__MODULE__{
+    task: Honeydew.task,
+    queue: Honeydew.queue_name,
+  }
+
+  @doc false
   def fields, do: @fields
 
   vars = @fields |> Enum.map(&Macro.var(&1, __MODULE__))
   vars_keyword_list = Enum.zip(@fields, vars)
 
+  @doc false
   def new(task, queue) do
     %__MODULE__{task: task, queue: queue, enqueued_at: System.system_time(:millisecond)}
   end
 
+  @doc false
   def to_record(%{unquote_splicing(vars_keyword_list)}, name) do
     {name, unquote_splicing(vars)}
   end
 
+  @doc false
   def to_record({_name, unquote_splicing(vars)}, name) do
     {name, unquote_splicing(vars)}
   end
 
+  @doc false
   def to_record({_name, unquote_splicing(vars)}) do
     {:job, unquote_splicing(vars)}
   end
 
+  @doc false
   def from_record({_name, unquote_splicing(vars)}) do
     %__MODULE__{unquote_splicing(vars_keyword_list)}
   end
 
+  @doc false
   def match_spec(map, name) do
     @match_spec
     |> Map.merge(map)

--- a/lib/honeydew/queue.ex
+++ b/lib/honeydew/queue.ex
@@ -2,6 +2,7 @@ defmodule Honeydew.Queue do
   use GenServer
   require Logger
   require Honeydew
+  alias Honeydew.Job
   alias Honeydew.Monitor
 
   defmodule State do
@@ -15,9 +16,9 @@ defmodule Honeydew.Queue do
       monitors: MapSet.new
   end
 
+  @type job :: Job.t
   @type private :: term
-  @type name :: term | {:global, term} # tighten this to a string or atom?
-  @type job :: %Honeydew.Job{}
+  @type name :: Honeydew.queue_name
 
   @callback init(name, arg :: term) :: {:ok, private}
   @callback enqueue(job, private) :: {private, job}
@@ -25,7 +26,7 @@ defmodule Honeydew.Queue do
   @callback ack(job, private) :: private
   @callback nack(job, private) :: private
   @callback status(private) :: %{:count => number, :in_progress => number, optional(atom) => any}
-  @callback filter(private, function) :: [job, ...]
+  @callback filter(private, function) :: [job]
   @callback cancel(job, private) :: {:ok | {:error, :in_progress} | nil, private}
 
   # stolen from GenServer, with a slight change

--- a/test/honeydew/queue/erlang_queue_integration_test.exs
+++ b/test/honeydew/queue/erlang_queue_integration_test.exs
@@ -10,6 +10,13 @@ defmodule Honeydew.ErlangQueueIntegrationTest do
     assert_receive :hi
   end
 
+  @tag :skip_worker_pool
+  test "async/3 when queue doesn't exist" do
+    assert_raise RuntimeError, fn ->
+      Honeydew.async({:send_msg, [self(), :hi]}, :nonexistent_queue)
+    end
+  end
+
   test "yield/2", %{queue: queue} do
     first_job  = {:return, [:hi]} |> Honeydew.async(queue, reply: true)
     second_job = {:return, [:there]} |> Honeydew.async(queue, reply: true)

--- a/test/honeydew/queue/mnesia_queue_integration_test.exs
+++ b/test/honeydew/queue/mnesia_queue_integration_test.exs
@@ -13,6 +13,13 @@ defmodule Honeydew.MnesiaQueueIntegrationTest do
     assert_receive :hi
   end
 
+  @tag :skip_worker_pool
+  test "async/3 when queue doesn't exist" do
+    assert_raise RuntimeError, fn ->
+      Honeydew.async({:send_msg, [self(), :hi]}, :nonexistent_queue)
+    end
+  end
+
   test "yield/2", %{queue: queue} do
     first_job  = {:return, [:hi]} |> Honeydew.async(queue, reply: true)
     second_job = {:return, [:there]} |> Honeydew.async(queue, reply: true)


### PR DESCRIPTION
This adds documentation and typespecs for the following functions:

  * `Honeydew.filter/2`
  * `Honeydew.async/3`
  * `Honeydew.yield/2`

It also adds a `Honeydew.Job.t` type and starts filling in the types for the various fields on that struct. Finally, this fixes the typespec on the `Honeydew.Queue.filter/2` callback. The previous callback said that `filter/2` should return a non-empty list, which is not required.