### PR TITLE
Documentation for cancel/1

### DIFF
--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -186,10 +186,10 @@ defmodule Honeydew do
 
   * `:ok` - Job had not been started and was able to be cancelled.
   * `{:error, :in_progress}` - Job was in progress and unable to be cancelled.
-  * `nil` - Job was not found on the queue (or already processed) and was unable
-    to be cancelled.
+  * `{:error, :not_found}` - Job was not found on the queue (or already
+      processed) and was unable to be cancelled.
   """
-  @spec cancel(Job.t) :: :ok | {:error, :in_progress} | nil
+  @spec cancel(Job.t) :: :ok | {:error, :in_progress} | {:error, :not_found}
   def cancel(%Job{queue: queue} = job) do
     queue
     |> get_queue

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -179,6 +179,17 @@ defmodule Honeydew do
     jobs
   end
 
+  @doc """
+  Cancels a job.
+
+  The return value depends on the status of the job.
+
+  * `:ok` - Job had not been started and was able to be cancelled.
+  * `{:error, :in_progress}` - Job was in progress and unable to be cancelled.
+  * `nil` - Job was not found on the queue (or already processed) and was unable
+    to be cancelled.
+  """
+  @spec cancel(Job.t) :: :ok | {:error, :in_progress} | nil
   def cancel(%Job{queue: queue} = job) do
     queue
     |> get_queue

--- a/lib/honeydew/queue.ex
+++ b/lib/honeydew/queue.ex
@@ -27,7 +27,7 @@ defmodule Honeydew.Queue do
   @callback nack(job, private) :: private
   @callback status(private) :: %{:count => number, :in_progress => number, optional(atom) => any}
   @callback filter(private, function) :: [job]
-  @callback cancel(job, private) :: {:ok | {:error, :in_progress} | nil, private}
+  @callback cancel(job, private) :: {:ok | {:error, :in_progress | :not_found}, private}
 
   # stolen from GenServer, with a slight change
   @callback handle_call(request :: term, GenServer.from, state :: private) ::

--- a/lib/honeydew/queue/erlang_queue.ex
+++ b/lib/honeydew/queue/erlang_queue.ex
@@ -8,6 +8,7 @@ defmodule Honeydew.Queue.ErlangQueue do
   """
   require Logger
   alias Honeydew.Job
+  alias Honeydew.Queue
 
   @behaviour Honeydew.Queue
 
@@ -68,6 +69,7 @@ defmodule Honeydew.Queue.ErlangQueue do
   end
 
   @impl true
+  @spec cancel(Job.t, Queue.private) :: {:ok | {:error, :in_progress} | nil, Queue.private}
   def cancel(%Job{private: private}, {pending, in_progress}) do
     filter = fn
       %Job{private: ^private} -> false;

--- a/lib/honeydew/queue/erlang_queue.ex
+++ b/lib/honeydew/queue/erlang_queue.ex
@@ -69,7 +69,7 @@ defmodule Honeydew.Queue.ErlangQueue do
   end
 
   @impl true
-  @spec cancel(Job.t, Queue.private) :: {:ok | {:error, :in_progress} | nil, Queue.private}
+  @spec cancel(Job.t, Queue.private) :: {:ok | {:error, :in_progress | :not_found}, Queue.private}
   def cancel(%Job{private: private}, {pending, in_progress}) do
     filter = fn
       %Job{private: ^private} -> false;
@@ -81,7 +81,7 @@ defmodule Honeydew.Queue.ErlangQueue do
     reply = cond do
       :queue.len(pending) > :queue.len(new_pending) -> :ok
       in_progress |> Map.values |> Enum.filter(&(!filter.(&1))) |> Enum.count > 0 -> {:error, :in_progress}
-      true -> nil
+      true -> {:error, :not_found}
     end
 
     {reply, {new_pending, in_progress}}

--- a/lib/honeydew/queue/mnesia.ex
+++ b/lib/honeydew/queue/mnesia.ex
@@ -177,7 +177,7 @@ defmodule Honeydew.Queue.Mnesia do
   end
 
   @impl true
-  @spec cancel(Job.t, Queue.private) :: {:ok | {:error, :in_progress} | nil, Queue.private}
+  @spec cancel(Job.t, Queue.private) :: {:ok | {:error, :in_progress | :not_found}, Queue.private}
   def cancel(%Job{private: {_, id}, }, %PState{table: table, access_context: access_context} = state) do
     reply =
       :mnesia.activity(access_context, fn ->
@@ -186,7 +186,7 @@ defmodule Honeydew.Queue.Mnesia do
         |> :mnesia.match_object
         |> Enum.map(&Job.to_record/1)
         |> case do
-             [] -> nil
+             [] -> {:error, :not_found}
              [Job.job(private: {false, id})] ->
                :ok = :mnesia.delete({table, {false, id}})
              [Job.job(private: {_node, _id})] ->

--- a/lib/honeydew/queue/mnesia.ex
+++ b/lib/honeydew/queue/mnesia.ex
@@ -13,6 +13,7 @@ defmodule Honeydew.Queue.Mnesia do
   require Honeydew.Job
   require Logger
   alias Honeydew.Job
+  alias Honeydew.Queue
 
   @behaviour Honeydew.Queue
 
@@ -176,6 +177,7 @@ defmodule Honeydew.Queue.Mnesia do
   end
 
   @impl true
+  @spec cancel(Job.t, Queue.private) :: {:ok | {:error, :in_progress} | nil, Queue.private}
   def cancel(%Job{private: {_, id}, }, %PState{table: table, access_context: access_context} = state) do
     reply =
       :mnesia.activity(access_context, fn ->

--- a/test/honeydew/queue/erlang_queue_integration_test.exs
+++ b/test/honeydew/queue/erlang_queue_integration_test.exs
@@ -92,6 +92,16 @@ defmodule Honeydew.ErlangQueueIntegrationTest do
     assert_receive :hi
   end
 
+  test "cancel/1 when has been processed", %{queue: queue} do
+    job = Honeydew.async({:send_msg, [self(), :hi]}, queue)
+    receive do
+      :hi -> :ok
+    end
+    Process.sleep(100) # Wait for job to be acked
+
+    assert {:error, :not_found} = Honeydew.cancel(job)
+  end
+
   test "pause queue, enqueue many, filter and cancel some, resume queue", %{queue: queue} do
     Honeydew.suspend(queue)
 

--- a/test/honeydew/queue/mnesia_queue_integration_test.exs
+++ b/test/honeydew/queue/mnesia_queue_integration_test.exs
@@ -111,6 +111,16 @@ defmodule Honeydew.MnesiaQueueIntegrationTest do
     assert_receive :hi
   end
 
+  test "cancel/1 when has been processed", %{queue: queue} do
+    job = Honeydew.async({:send_msg, [self(), :hi]}, queue)
+    receive do
+      :hi -> :ok
+    end
+    Process.sleep(100) # Wait for job to be acked
+
+    assert {:error, :not_found} = Honeydew.cancel(job)
+  end
+
   test "pause queue, enqueue many, filter and cancel some, resume queue", %{queue: queue} do
     Honeydew.suspend(queue)
 


### PR DESCRIPTION
This documents `Honeydew.cancel/1` and adds typespecs for `cancel/1` in the two queue implementations.