### PR TITLE
Fix Honeydew.yield/2 typespec

### DIFF
--- a/test/honeydew/queue/erlang_queue_integration_test.exs
+++ b/test/honeydew/queue/erlang_queue_integration_test.exs
@@ -1,11 +1,17 @@
 defmodule Honeydew.ErlangQueueIntegrationTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   alias Honeydew.Job
 
   setup [
     :setup_queue_name,
     :setup_queue,
     :setup_worker_pool]
+
+  describe "doctests" do
+    setup [:start_doctest_env]
+
+    doctest Honeydew
+  end
 
   test "async/3", %{queue: queue} do
     %Job{} = {:send_msg, [self(), :hi]} |> Honeydew.async(queue)
@@ -26,6 +32,27 @@ defmodule Honeydew.ErlangQueueIntegrationTest do
 
     assert {:ok, :hi}    = Honeydew.yield(first_job)
     assert {:ok, :there} = Honeydew.yield(second_job)
+  end
+
+  test "yield/2 when job isn't started properly", %{queue: queue} do
+    job = Honeydew.async({:return, [:hi]}, queue)
+
+    assert_raise ArgumentError, ~r/set `:reply` to `true`/i,  fn ->
+      Honeydew.yield(job)
+    end
+  end
+
+  test "when yield/2 is called from a separate process", %{queue: queue} do
+    job =
+      fn ->
+        Honeydew.async({:return, [:hi]}, queue, reply: true)
+      end
+      |> Task.async
+      |> Task.await
+
+    assert_raise ArgumentError, ~r/the owner/i, fn ->
+      Honeydew.yield(job)
+    end
   end
 
   test "suspend/1", %{queue: queue} do
@@ -279,5 +306,13 @@ defmodule Honeydew.ErlangQueueIntegrationTest do
 
   defp start_worker_pool(queue) do
     Helper.start_worker_link(queue, Stateless)
+  end
+
+  defp start_doctest_env(_) do
+    queue = :my_queue
+    start_queue(queue)
+    Helper.start_worker_link(queue, DocTestWorker)
+
+    :ok
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -25,6 +25,13 @@ defmodule Stateless do
   end
 end
 
+defmodule DocTestWorker do
+  def ping(_ip) do
+    Process.sleep(3000)
+    :pong
+  end
+end
+
 defmodule Stateful do
   @behaviour Honeydew.Worker
   def init(state) do


### PR DESCRIPTION
Looks like Honeydew.yield/2 returns `{:ok, result}` instead of just result. This fixes the docs and adds some test coverage.