### PR TITLE
fix time_in_msecs_sql fragment

### DIFF
--- a/lib/honeydew/ecto_poll_queue.ex
+++ b/lib/honeydew/ecto_poll_queue.ex
@@ -90,7 +90,7 @@ defmodule Honeydew.EctoPollQueue do
 
         unquote(queue)
         |> Honeydew.EctoSource.field_name(:lock)
-        |> Ecto.Migration.add(:integer, default: SQL.ready_fragment())
+        |> Ecto.Migration.add(:bigint, default: SQL.ready_fragment())
 
         unquote(queue)
         |> Honeydew.EctoSource.field_name(:private)

--- a/lib/honeydew/sources/ecto/sql.ex
+++ b/lib/honeydew/sources/ecto/sql.ex
@@ -10,7 +10,7 @@ defmodule Honeydew.EctoSource.SQL do
 
   @spec time_in_msecs_sql(sql_fragment) :: sql_fragment
   def time_in_msecs_sql(time) do
-    "CAST(EXTRACT(epoch from (#{time})) * 1000 AS INT)"
+    "CAST(EXTRACT(epoch from (#{time})) * 1000 AS BIGINT)"
   end
 
   @spec now_msecs_sql() :: sql_fragment

--- a/lib/honeydew/sources/ecto/sql.ex
+++ b/lib/honeydew/sources/ecto/sql.ex
@@ -31,18 +31,8 @@ defmodule Honeydew.EctoSource.SQL do
     end
   end
 
-  # "I left in love, in laughter, and in truth. And wherever truth, love and laughter abide, I am there in spirit."
-  @spec far_in_the_past() :: NaiveDateTime.t()
-  def far_in_the_past do
-    ~N[1994-03-26 04:20:00]
-  end
-
   defmacro ready_fragment do
-    sql =
-      "CAST('#{far_in_the_past()}' AS TIMESTAMP)"
-      |> time_in_msecs_sql
-      |> msecs_ago_sql
-
+    sql = now_msecs_sql()
     quote do
       fragment(unquote(sql))
     end

--- a/lib/honeydew/sources/ecto/sql.ex
+++ b/lib/honeydew/sources/ecto/sql.ex
@@ -10,7 +10,7 @@ defmodule Honeydew.EctoSource.SQL do
 
   @spec time_in_msecs_sql(sql_fragment) :: sql_fragment
   def time_in_msecs_sql(time) do
-    "(EXTRACT('millisecond', (#{time})) + CAST((#{time}) AS INT) * 1000)"
+    "CAST(EXTRACT(epoch from (#{time})) * 1000 AS INT)"
   end
 
   @spec now_msecs_sql() :: sql_fragment


### PR DESCRIPTION
fixes #48 . Postgres 'epoch' date part will extract time in seconds with microsecond precision (as a float). So we multiply that by 1000.