### PR TITLE
Use new supervisor spec

### DIFF
--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -363,13 +363,12 @@ defmodule Honeydew do
     supervisor_opts =
       opts
       |> Keyword.get(:supervisor_opts, [])
-      |> Keyword.put_new(:id, {:queue, name})
       |> Keyword.put_new(:restart, :permanent)
       |> Keyword.put_new(:shutdown, :infinity)
       |> Enum.into(%{})
 
     spec = %{
-      id: Honeydew.QueueSupervisor,
+      id: {:queue, name},
       start: {Honeydew.QueueSupervisor, :start_link,
               [name, module, args, num, dispatcher, failure_mode, success_mode, suspended]},
     }

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -369,6 +369,7 @@ defmodule Honeydew do
       id: {:queue, name},
       start: {Honeydew.QueueSupervisor, :start_link,
               [name, module, args, num, dispatcher, failure_mode, success_mode, suspended]},
+      type: :supervisor
     }
 
     Map.merge(spec, supervisor_opts)

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -306,7 +306,7 @@ defmodule Honeydew do
      can pass either a module, or `{module, args}`. The module must implement
      the `Honeydew.SuccessMode` behaviour. Defaults to `nil`.
 
-  - `supervisor_opts`: options accepted by `Supervisor.Spec.supervisor/3`.
+  - `supervisor_opts`: options accepted by `Supervisor.child_spec()`.
 
   - `suspended`: Start queue in suspended state. Defaults to `false`.
 
@@ -317,7 +317,7 @@ defmodule Honeydew do
   - `Honeydew.queue_spec("my_awesome_queue", queue: {MyQueueModule, [ip: "localhost"]},
                                              dispatcher: {Honeydew.Dispatcher.MRU, []})`
   """
-  @spec queue_spec(queue_name, [queue_spec_opt]) :: Supervisor.Spec.spec
+  @spec queue_spec(queue_name, [queue_spec_opt]) :: Supervisor.child_spec()
   def queue_spec(name, opts \\ []) do
     {module, args} =
       case opts[:queue] do
@@ -384,7 +384,7 @@ defmodule Honeydew do
 
   # @deprecated "Use module based child specs with Honeydew.Workers instead"
   # @since "1.1.1"
-  @spec worker_spec(queue_name, mod_or_mod_args, [worker_spec_opt]) :: Supervisor.Spec.spec
+  @spec worker_spec(queue_name, mod_or_mod_args, [worker_spec_opt]) :: Supervisor.child_spec()
   def worker_spec(queue, module_and_args, opts \\ []) do
     Honeydew.Workers.child_spec([queue, module_and_args | opts])
   end

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -364,11 +364,17 @@ defmodule Honeydew do
       opts
       |> Keyword.get(:supervisor_opts, [])
       |> Keyword.put_new(:id, {:queue, name})
+      |> Keyword.put_new(:restart, :permanent)
+      |> Keyword.put_new(:shutdown, :infinity)
+      |> Enum.into(%{})
 
-    Supervisor.Spec.supervisor(
-      Honeydew.QueueSupervisor,
-      [name, module, args, num, dispatcher, failure_mode, success_mode, suspended],
-      supervisor_opts)
+    spec = %{
+      id: Honeydew.QueueSupervisor,
+      start: {Honeydew.QueueSupervisor, :start_link,
+              [name, module, args, num, dispatcher, failure_mode, success_mode, suspended]},
+    }
+
+    Map.merge(spec, supervisor_opts)
   end
 
   @type worker_spec_opt ::

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -363,8 +363,6 @@ defmodule Honeydew do
     supervisor_opts =
       opts
       |> Keyword.get(:supervisor_opts, [])
-      |> Keyword.put_new(:restart, :permanent)
-      |> Keyword.put_new(:shutdown, :infinity)
       |> Enum.into(%{})
 
     spec = %{

--- a/lib/honeydew/ecto_poll_queue.ex
+++ b/lib/honeydew/ecto_poll_queue.ex
@@ -32,7 +32,7 @@ defmodule Honeydew.EctoPollQueue do
 
   - `Honeydew.queue_spec(:classify_photos, repo: MyApp.Repo, schema: MyApp.Photo failure_mode: {Honeydew.Retry, times: 3})`
   """
-  @spec child_spec([queue_name | ecto_poll_queue_spec_opt]) :: Supervisor.Spec.spec
+  @spec child_spec([queue_name | ecto_poll_queue_spec_opt]) :: Supervisor.child_spec()
   def child_spec([queue_name | opts]) do
     {poll_interval, opts} = Keyword.pop(opts, :poll_interval)
     {stale_timeout, opts} = Keyword.pop(opts, :stale_timeout)

--- a/lib/honeydew/node_monitor.ex
+++ b/lib/honeydew/node_monitor.ex
@@ -4,13 +4,6 @@ defmodule Honeydew.NodeMonitor do
 
   @interval 1_000 # ms
 
-  def child_spec(opts) do
-    %{
-      id: __MODULE__,
-      start: {__MODULE__, :start_link, opts}
-    }
-  end
-
   def start_link(node) do
     GenServer.start_link(__MODULE__, node)
   end

--- a/lib/honeydew/node_monitor.ex
+++ b/lib/honeydew/node_monitor.ex
@@ -4,6 +4,13 @@ defmodule Honeydew.NodeMonitor do
 
   @interval 1_000 # ms
 
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts}
+    }
+  end
+
   def start_link(node) do
     GenServer.start_link(__MODULE__, node)
   end

--- a/lib/honeydew/node_monitor_supervisor.ex
+++ b/lib/honeydew/node_monitor_supervisor.ex
@@ -1,25 +1,23 @@
 defmodule Honeydew.NodeMonitorSupervisor do
   alias Honeydew.NodeMonitor
 
-  def child_spec(opts) do
+  def child_spec([queue, _nodes] = opts) do
     %{
-      id: __MODULE__,
+      id: Honeydew.supervisor(queue, :node_monitor),
       start: {__MODULE__, :start_link, opts}
     }
   end
 
   def start_link(queue, nodes) do
-    children = [{NodeMonitor, [], restart: :transient}]
-
     opts = [
       name: Honeydew.supervisor(queue, :node_monitor),
-      strategy: :simple_one_for_one
+      strategy: :one_for_one
     ]
 
-    {:ok, supervisor} = Supervisor.start_link(children, opts)
+    {:ok, supervisor} = DynamicSupervisor.start_link(opts)
 
     Enum.each(nodes, fn node ->
-      Supervisor.start_child(supervisor, [node])
+      DynamicSupervisor.start_child(supervisor, [node])
     end)
 
     {:ok, supervisor}

--- a/lib/honeydew/node_monitor_supervisor.ex
+++ b/lib/honeydew/node_monitor_supervisor.ex
@@ -2,9 +2,7 @@ defmodule Honeydew.NodeMonitorSupervisor do
   alias Honeydew.NodeMonitor
 
   def start_link(queue, nodes) do
-    import Supervisor.Spec
-
-    children = [worker(NodeMonitor, [], restart: :transient)]
+    children = [{NodeMonitor, [], restart: :transient}]
 
     opts = [
       name: Honeydew.supervisor(queue, :node_monitor),

--- a/lib/honeydew/node_monitor_supervisor.ex
+++ b/lib/honeydew/node_monitor_supervisor.ex
@@ -17,7 +17,7 @@ defmodule Honeydew.NodeMonitorSupervisor do
     {:ok, supervisor} = DynamicSupervisor.start_link(opts)
 
     Enum.each(nodes, fn node ->
-      DynamicSupervisor.start_child(supervisor, [node])
+      DynamicSupervisor.start_child(supervisor, {NodeMonitor, [node]})
     end)
 
     {:ok, supervisor}

--- a/lib/honeydew/node_monitor_supervisor.ex
+++ b/lib/honeydew/node_monitor_supervisor.ex
@@ -4,15 +4,13 @@ defmodule Honeydew.NodeMonitorSupervisor do
   def child_spec([queue, _nodes] = opts) do
     %{
       id: Honeydew.supervisor(queue, :node_monitor),
-      start: {__MODULE__, :start_link, opts}
+      start: {__MODULE__, :start_link, opts},
+      supervisor: true
     }
   end
 
   def start_link(queue, nodes) do
-    opts = [
-      name: Honeydew.supervisor(queue, :node_monitor),
-      strategy: :one_for_one
-    ]
+    opts = [name: Honeydew.supervisor(queue, :node_monitor)]
 
     {:ok, supervisor} = DynamicSupervisor.start_link(opts)
 

--- a/lib/honeydew/node_monitor_supervisor.ex
+++ b/lib/honeydew/node_monitor_supervisor.ex
@@ -1,6 +1,13 @@
 defmodule Honeydew.NodeMonitorSupervisor do
   alias Honeydew.NodeMonitor
 
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts}
+    }
+  end
+
   def start_link(queue, nodes) do
     children = [{NodeMonitor, [], restart: :transient}]
 

--- a/lib/honeydew/queue.ex
+++ b/lib/honeydew/queue.ex
@@ -53,6 +53,13 @@ defmodule Honeydew.Queue do
 
   @optional_callbacks handle_call: 3, handle_cast: 2, handle_info: 2
 
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts}
+    }
+  end
+
   def start_link(queue, module, args, dispatcher, failure_mode, success_mode, suspended) do
     GenServer.start_link(__MODULE__, [queue, module, args, dispatcher, failure_mode, success_mode, suspended])
   end

--- a/lib/honeydew/queue_monitor.ex
+++ b/lib/honeydew/queue_monitor.ex
@@ -7,9 +7,9 @@ defmodule Honeydew.QueueMonitor do
     defstruct [:worker_group_pid, :queue_pid]
   end
 
-  def child_spec(opts) do
+  def child_spec(opts, queue: queue) do
     %{
-      id: __MODULE__,
+      id: {__MODULE__, queue},
       start: {__MODULE__, :start_link, opts}
     }
   end

--- a/lib/honeydew/queue_monitor.ex
+++ b/lib/honeydew/queue_monitor.ex
@@ -7,6 +7,13 @@ defmodule Honeydew.QueueMonitor do
     defstruct [:worker_group_pid, :queue_pid]
   end
 
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts}
+    }
+  end
+
   def start_link(worker_group_pid, queue_pid) do
     GenServer.start_link(__MODULE__, [worker_group_pid, queue_pid])
   end

--- a/lib/honeydew/queue_supervisor.ex
+++ b/lib/honeydew/queue_supervisor.ex
@@ -9,14 +9,13 @@ defmodule Honeydew.QueueSupervisor do
             # if a queue dies because it's trying to connect to a remote host,
             # should we delay the restart like with workers?
             max_restarts: num_queues,
-            max_seconds: 5,
-            extra_arguments: [queue, module, args, dispatcher, failure_mode, success_mode, suspended]]
+            max_seconds: 5]
 
     {:ok, supervisor} = DynamicSupervisor.start_link(opts)
 
     # start up workers
     Enum.each(1..num_queues, fn _ ->
-      {:ok, _} = DynamicSupervisor.start_child(supervisor, {Honeydew.Queue, []})
+      {:ok, _} = DynamicSupervisor.start_child(supervisor, {Honeydew.Queue, [queue, module, args, dispatcher, failure_mode, success_mode, suspended]})
     end)
 
     {:ok, supervisor}

--- a/lib/honeydew/queue_supervisor.ex
+++ b/lib/honeydew/queue_supervisor.ex
@@ -3,23 +3,20 @@ defmodule Honeydew.QueueSupervisor do
   def start_link(queue, module, args, num_queues, dispatcher, failure_mode, success_mode, suspended) do
     Honeydew.create_groups(queue)
 
-    children = [
-      {Honeydew.Queue, [queue, module, args, dispatcher, failure_mode, success_mode, suspended]}
-    ]
-
-    opts = [strategy: :simple_one_for_one,
+    opts = [strategy: :one_for_one,
             name: Honeydew.supervisor(queue, :queue),
             # what would be sane settings here?
             # if a queue dies because it's trying to connect to a remote host,
             # should we delay the restart like with workers?
             max_restarts: num_queues,
-            max_seconds: 5]
+            max_seconds: 5,
+            extra_arguments: [queue, module, args, dispatcher, failure_mode, success_mode, suspended]]
 
-    {:ok, supervisor} = Supervisor.start_link(children, opts)
+    {:ok, supervisor} = DynamicSupervisor.start_link(opts)
 
     # start up workers
     Enum.each(1..num_queues, fn _ ->
-      {:ok, _} = Supervisor.start_child(supervisor, [])
+      {:ok, _} = DynamicSupervisor.start_child(supervisor, {Honeydew.Queue, []})
     end)
 
     {:ok, supervisor}

--- a/lib/honeydew/queue_supervisor.ex
+++ b/lib/honeydew/queue_supervisor.ex
@@ -1,12 +1,10 @@
 defmodule Honeydew.QueueSupervisor do
 
   def start_link(queue, module, args, num_queues, dispatcher, failure_mode, success_mode, suspended) do
-    import Supervisor.Spec
-
     Honeydew.create_groups(queue)
 
     children = [
-      worker(Honeydew.Queue, [queue, module, args, dispatcher, failure_mode, success_mode, suspended])
+      {Honeydew.Queue, [queue, module, args, dispatcher, failure_mode, success_mode, suspended]}
     ]
 
     opts = [strategy: :simple_one_for_one,

--- a/lib/honeydew/worker.ex
+++ b/lib/honeydew/worker.ex
@@ -14,18 +14,16 @@ defmodule Honeydew.Worker do
     defstruct [:queue, :queue_pid, :module, :user_state]
   end
 
-  def child_spec(opts, [restart: restart, shutdown: shutdown]) do
+  def child_spec(opts) do
     %{
       id: __MODULE__,
-      start: {__MODULE__, :start_link, opts},
-      restart: restart,
-      shutdown: shutdown
+      start: {__MODULE__, :start_link, opts}
     }
   end
 
   @doc false
-  def start_link(queue, %{ma: {module, args}, init_retry: init_retry_secs}, queue_pid) do
-    GenServer.start_link(__MODULE__, [queue, queue_pid, module, args, init_retry_secs])
+  def start_link(queue, %{ma: {module, args}, init_retry: init_retry_secs, restart: restart, shutdown: shutdown}, queue_pid) do
+    GenServer.start_link(__MODULE__, [queue, queue_pid, module, args, init_retry_secs], restart: restart, shutdown: shutdown)
   end
 
   def init([queue, queue_pid, module, args, init_retry_secs]) do

--- a/lib/honeydew/worker.ex
+++ b/lib/honeydew/worker.ex
@@ -14,6 +14,15 @@ defmodule Honeydew.Worker do
     defstruct [:queue, :queue_pid, :module, :user_state]
   end
 
+  def child_spec(opts, [restart: restart, shutdown: shutdown]) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts},
+      restart: restart,
+      shutdown: shutdown
+    }
+  end
+
   @doc false
   def start_link(queue, %{ma: {module, args}, init_retry: init_retry_secs}, queue_pid) do
     GenServer.start_link(__MODULE__, [queue, queue_pid, module, args, init_retry_secs])

--- a/lib/honeydew/worker_group_supervisor.ex
+++ b/lib/honeydew/worker_group_supervisor.ex
@@ -10,7 +10,7 @@ defmodule Honeydew.WorkerGroupSupervisor do
 
   def start_link(queue, opts, queue_pid) do
     children = [
-      {QueueMonitor, [self(), queue_pid]},
+      QueueMonitor.child_spec([self(), queue_pid], queue: queue),
       {WorkerSupervisor, [queue, opts, queue_pid]}
     ]
 

--- a/lib/honeydew/worker_group_supervisor.ex
+++ b/lib/honeydew/worker_group_supervisor.ex
@@ -4,7 +4,8 @@ defmodule Honeydew.WorkerGroupSupervisor do
   def child_spec(opts) do
     %{
       id: __MODULE__,
-      start: {__MODULE__, :start_link, opts}
+      start: {__MODULE__, :start_link, opts},
+      type: :supervisor
     }
   end
 

--- a/lib/honeydew/worker_group_supervisor.ex
+++ b/lib/honeydew/worker_group_supervisor.ex
@@ -1,11 +1,18 @@
 defmodule Honeydew.WorkerGroupSupervisor do
   alias Honeydew.{QueueMonitor, WorkerSupervisor}
 
-  def start_link(queue, opts, queue_pid) do
-    import Supervisor.Spec
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts}
+    }
+  end
 
-    children = [worker(QueueMonitor, [self(), queue_pid]),
-                supervisor(WorkerSupervisor, [queue, opts, queue_pid])]
+  def start_link(queue, opts, queue_pid) do
+    children = [
+      {QueueMonitor, [self(), queue_pid]},
+      {WorkerSupervisor, [queue, opts, queue_pid]}
+    ]
 
     supervisor_opts = [strategy: :one_for_one,
                        name: Honeydew.supervisor(queue, :worker_group)]

--- a/lib/honeydew/worker_groups_supervisor.ex
+++ b/lib/honeydew/worker_groups_supervisor.ex
@@ -9,15 +9,14 @@ defmodule Honeydew.WorkerGroupsSupervisor do
   end
 
   def start_link(queue, opts) do
-    children = [{WorkerGroupSupervisor, [queue, opts]}]
+    supervisor_opts = [strategy: :one_for_one,
+                       name: Honeydew.supervisor(queue, :worker_groups),
+                       extra_arguments: [queue, opts]]
 
-    supervisor_opts = [strategy: :simple_one_for_one,
-                       name: Honeydew.supervisor(queue, :worker_groups)]
-
-    Supervisor.start_link(children, supervisor_opts)
+    DynamicSupervisor.start_link(supervisor_opts)
   end
 
   def start_group(supervisor, queue_pid) do
-    {:ok, _group} = Supervisor.start_child(supervisor, [queue_pid])
+    {:ok, _group} = DynamicSupervisor.start_child(supervisor, {WorkerGroupSupervisor, [queue_pid]})
   end
 end

--- a/lib/honeydew/worker_groups_supervisor.ex
+++ b/lib/honeydew/worker_groups_supervisor.ex
@@ -2,9 +2,7 @@ defmodule Honeydew.WorkerGroupsSupervisor do
   alias Honeydew.WorkerGroupSupervisor
 
   def start_link(queue, opts) do
-    import Supervisor.Spec
-
-    children = [supervisor(WorkerGroupSupervisor, [queue, opts])]
+    children = [{WorkerGroupSupervisor, [queue, opts]}]
 
     supervisor_opts = [strategy: :simple_one_for_one,
                        name: Honeydew.supervisor(queue, :worker_groups)]

--- a/lib/honeydew/worker_groups_supervisor.ex
+++ b/lib/honeydew/worker_groups_supervisor.ex
@@ -4,7 +4,8 @@ defmodule Honeydew.WorkerGroupsSupervisor do
   def child_spec(opts) do
     %{
       id: __MODULE__,
-      start: {__MODULE__, :start_link, opts}
+      start: {__MODULE__, :start_link, opts},
+      type: :supervisor
     }
   end
 

--- a/lib/honeydew/worker_groups_supervisor.ex
+++ b/lib/honeydew/worker_groups_supervisor.ex
@@ -1,6 +1,13 @@
 defmodule Honeydew.WorkerGroupsSupervisor do
   alias Honeydew.WorkerGroupSupervisor
 
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts}
+    }
+  end
+
   def start_link(queue, opts) do
     children = [{WorkerGroupSupervisor, [queue, opts]}]
 

--- a/lib/honeydew/worker_starter.ex
+++ b/lib/honeydew/worker_starter.ex
@@ -4,6 +4,13 @@ defmodule Honeydew.WorkerStarter do
   alias Honeydew.WorkerGroupsSupervisor
   require Logger
 
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts}
+    }
+  end
+
   def start_link(queue) do
     GenServer.start_link(__MODULE__, queue, name: Honeydew.process(queue, :worker_starter))
   end

--- a/lib/honeydew/worker_supervisor.ex
+++ b/lib/honeydew/worker_supervisor.ex
@@ -4,7 +4,8 @@ defmodule Honeydew.WorkerSupervisor do
   def child_spec(opts) do
     %{
       id: __MODULE__,
-      start: {__MODULE__, :start_link, opts}
+      start: {__MODULE__, :start_link, opts},
+      type: :supervisor
     }
   end
 

--- a/lib/honeydew/worker_supervisor.ex
+++ b/lib/honeydew/worker_supervisor.ex
@@ -8,19 +8,18 @@ defmodule Honeydew.WorkerSupervisor do
     }
   end
 
-  def start_link(queue, %{shutdown: shutdown, init_retry: init_retry_secs, num: num} = opts, queue_pid) do
-    children = [
-      Worker.child_spec([queue, opts, queue_pid], [restart: :transient, shutdown: shutdown])
-    ]
+  def start_link(queue, %{shutdown: _shutdown, init_retry: init_retry_secs, num: num} = opts, queue_pid) do
+    opts = Enum.into(opts, %{restart: :transient})
 
     supervisor_opts = [
-      strategy: :simple_one_for_one,
+      strategy: :one_for_one,
       name: Honeydew.supervisor(queue, :worker),
       max_restarts: num,
-      max_seconds: init_retry_secs
+      max_seconds: init_retry_secs,
+      extra_arguments: [queue, opts, queue_pid]
     ]
 
-    {:ok, supervisor} = Supervisor.start_link(children, supervisor_opts)
+    {:ok, supervisor} = DynamicSupervisor.start_link(supervisor_opts)
 
     start_workers(supervisor, num)
 
@@ -30,7 +29,7 @@ defmodule Honeydew.WorkerSupervisor do
   defp start_workers(_supervisor, 0), do: :noop
 
   defp start_workers(supervisor, num) do
-    Supervisor.start_child(supervisor, [])
+    DynamicSupervisor.start_child(supervisor, {Worker, []})
     start_workers(supervisor, num - 1)
   end
 end

--- a/lib/honeydew/worker_supervisor.ex
+++ b/lib/honeydew/worker_supervisor.ex
@@ -1,10 +1,17 @@
 defmodule Honeydew.WorkerSupervisor do
   alias Honeydew.Worker
 
-  def start_link(queue, %{shutdown: shutdown, init_retry: init_retry_secs, num: num} = opts, queue_pid) do
-    import Supervisor.Spec
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts}
+    }
+  end
 
-    children = [worker(Worker, [queue, opts, queue_pid], restart: :transient, shutdown: shutdown)]
+  def start_link(queue, %{shutdown: shutdown, init_retry: init_retry_secs, num: num} = opts, queue_pid) do
+    children = [
+      Worker.child_spec([queue, opts, queue_pid], [restart: :transient, shutdown: shutdown])
+    ]
 
     supervisor_opts = [
       strategy: :simple_one_for_one,

--- a/lib/honeydew/workers.ex
+++ b/lib/honeydew/workers.ex
@@ -72,12 +72,12 @@ defmodule Honeydew.Workers do
 
 
   def start_link(queue, %{nodes: nodes} = opts) do
-    import Supervisor.Spec
-
     Honeydew.create_groups(queue)
 
-    children = [supervisor(WorkerGroupsSupervisor, [queue, opts]),
-                worker(WorkerStarter, [queue])]
+    children = [
+      {WorkerGroupsSupervisor, [queue, opts]},
+      {WorkerStarter, [queue]}
+    ]
 
     # if the worker groups supervisor shuts down due to too many groups
     # restarting (hits max intensity), we also want the WorkerStarter to die
@@ -88,7 +88,7 @@ defmodule Honeydew.Workers do
 
     queue
     |> case do
-         {:global, _} -> children ++ [supervisor(Honeydew.NodeMonitorSupervisor, [queue, nodes])]
+         {:global, _} -> children ++ [{Honeydew.NodeMonitorSupervisor, [queue, nodes]}]
          _ -> children
        end
     |> Supervisor.start_link(supervisor_opts)

--- a/lib/honeydew/workers.ex
+++ b/lib/honeydew/workers.ex
@@ -23,7 +23,7 @@ defmodule Honeydew.Workers do
   - `shutdown`: if a worker is in the middle of a job, the amount of time, in
      milliseconds, to wait before brutally killing it. Defaults to `10_000`.
 
-  - `supervisor_opts` options accepted by `Supervisor.Spec.supervisor/3`.
+  - `supervisor_opts` options accepted by `Supervisor.child_spec()`.
 
   - `nodes`: for :global queues, you can provide a list of nodes to stay
      connected to (your queue node and enqueuing nodes). Defaults to `[]`.
@@ -36,8 +36,8 @@ defmodule Honeydew.Workers do
 
   - `Honeydew.child_spec({:global, "my_awesome_queue"}, MyJobModule, nodes: [:clientfacing@dax, :queue@dax])`
   """
-  # @spec child_spec([queue_name, mod_or_mod_args, [worker_spec_opt]]) :: Supervisor.Spec.spec
-  @spec child_spec([...]) :: Supervisor.Spec.spec
+  # @spec child_spec([queue_name, mod_or_mod_args, [worker_spec_opt]]) :: Supervisor.child_spec()
+  @spec child_spec([...]) :: Supervisor.child_spec()
   def child_spec([queue, module_and_args]), do: child_spec([queue, module_and_args, []])
 
   def child_spec([queue, module_and_args | opts]) do

--- a/lib/honeydew/workers.ex
+++ b/lib/honeydew/workers.ex
@@ -62,7 +62,8 @@ defmodule Honeydew.Workers do
 
     spec = %{
       id: {:worker, queue},
-      start: {__MODULE__, :start_link, [queue, opts]}
+      start: {__MODULE__, :start_link, [queue, opts]},
+      type: :supervisor
     }
 
     Map.merge(spec, supervisor_opts)

--- a/lib/honeydew/workers.ex
+++ b/lib/honeydew/workers.ex
@@ -50,8 +50,6 @@ defmodule Honeydew.Workers do
     supervisor_opts =
       opts
       |> Keyword.get(:supervisor_opts, [])
-      |> Keyword.put_new(:restart, :permanent)
-      |> Keyword.put_new(:shutdown, :infinity)
       |> Enum.into(%{})
 
     opts = %{

--- a/lib/honeydew/workers.ex
+++ b/lib/honeydew/workers.ex
@@ -50,7 +50,9 @@ defmodule Honeydew.Workers do
     supervisor_opts =
       opts
       |> Keyword.get(:supervisor_opts, [])
-      |> Keyword.put_new(:id, {:worker, queue})
+      |> Keyword.put_new(:restart, :permanent)
+      |> Keyword.put_new(:shutdown, :infinity)
+      |> Enum.into(%{})
 
     opts = %{
       ma: {module, args},
@@ -60,7 +62,12 @@ defmodule Honeydew.Workers do
       nodes: opts[:nodes] || []
     }
 
-    Supervisor.Spec.supervisor(__MODULE__, [queue, opts], supervisor_opts)
+    spec = %{
+      id: {:worker, queue},
+      start: {__MODULE__, :start_link, [queue, opts]}
+    }
+
+    Map.merge(spec, supervisor_opts)
   end
 
 

--- a/test/honeydew/ecto_poll_queue_test.exs
+++ b/test/honeydew/ecto_poll_queue_test.exs
@@ -27,54 +27,67 @@ defmodule Honeydew.EctoPollQueueTest do
                                        stale_timeout: 456,
                                        failure_mode: {Abandon, []}])
 
-      assert spec == {{:queue, queue},
-                      {Honeydew.QueueSupervisor, :start_link,
-                      [queue,
-                        Honeydew.PollQueue, [Honeydew.EctoSource, [schema: :my_schema,
-                                                                   repo: PseudoRepo,
-                                                                   sql: SQL.Postgres,
-                                                                   poll_interval: 123,
-                                                                   stale_timeout: 456]],
-                        1,
-                        {Honeydew.Dispatcher.LRU, []},
-                        {Abandon, []},
-                        nil, false]}, :permanent, :infinity, :supervisor, [Honeydew.QueueSupervisor]}
+      assert spec == %{
+        id: {:queue, queue},
+        start: {Honeydew.QueueSupervisor, :start_link,
+                [queue,
+                 Honeydew.PollQueue, [Honeydew.EctoSource, [schema: :my_schema,
+                                                            repo: PseudoRepo,
+                                                            sql: SQL.Postgres,
+                                                            poll_interval: 123,
+                                                            stale_timeout: 456]],
+                 1,
+                 {Honeydew.Dispatcher.LRU, []},
+                 {Abandon, []},
+                 nil, false]},
+        restart: :permanent,
+        shutdown: :infinity
+      }
     end
 
     test "defaults" do
       queue = :erlang.unique_integer
       spec = EctoPollQueue.child_spec([queue, schema: :my_schema, repo: PseudoRepo])
 
-      assert spec == {{:queue, queue},
-                      {Honeydew.QueueSupervisor, :start_link,
-                       [queue,
-                        Honeydew.PollQueue, [Honeydew.EctoSource, [schema: :my_schema,
-                                                                   repo: PseudoRepo,
-                                                                   sql: SQL.Postgres,
-                                                                   poll_interval: 10,
-                                                                   stale_timeout: 300]],
-                        1,
-                        {Honeydew.Dispatcher.LRU, []},
-                        {Abandon, []},
-                        nil, false]}, :permanent, :infinity, :supervisor, [Honeydew.QueueSupervisor]}
+      assert spec == %{
+        id: {:queue, queue},
+        start: {Honeydew.QueueSupervisor, :start_link,
+                [queue,
+                 Honeydew.PollQueue, [Honeydew.EctoSource, [schema: :my_schema,
+                                                            repo: PseudoRepo,
+                                                            sql: SQL.Postgres,
+                                                            poll_interval: 10,
+                                                            stale_timeout: 300]],
+                 1,
+                 {Honeydew.Dispatcher.LRU, []},
+                 {Abandon, []},
+                 nil, false]},
+        restart: :permanent,
+        shutdown: :infinity
+      }
     end
 
     test "cockroachdb" do
       queue = :erlang.unique_integer
       spec = EctoPollQueue.child_spec([queue, schema: :my_schema, repo: PseudoRepo, database: :cockroachdb])
 
-      assert spec == {{:queue, queue},
-                      {Honeydew.QueueSupervisor, :start_link,
-                       [queue,
-                        Honeydew.PollQueue, [Honeydew.EctoSource, [schema: :my_schema,
-                                                                   repo: PseudoRepo,
-                                                                   sql: SQL.Cockroach,
-                                                                   poll_interval: 10,
-                                                                   stale_timeout: 300]],
-                        1,
-                        {Honeydew.Dispatcher.LRU, []},
-                        {Abandon, []},
-                        nil, false]}, :permanent, :infinity, :supervisor, [Honeydew.QueueSupervisor]}
+
+      assert spec == %{
+        id: {:queue, queue},
+        start: {Honeydew.QueueSupervisor, :start_link,
+                [queue,
+                 Honeydew.PollQueue, [Honeydew.EctoSource, [schema: :my_schema,
+                                                            repo: PseudoRepo,
+                                                            sql: SQL.Cockroach,
+                                                            poll_interval: 10,
+                                                            stale_timeout: 300]],
+                 1,
+                 {Honeydew.Dispatcher.LRU, []},
+                 {Abandon, []},
+                 nil, false]},
+        restart: :permanent,
+        shutdown: :infinity
+      }
     end
 
     test "should raise when database isn't supported" do

--- a/test/honeydew/ecto_poll_queue_test.exs
+++ b/test/honeydew/ecto_poll_queue_test.exs
@@ -29,6 +29,7 @@ defmodule Honeydew.EctoPollQueueTest do
 
       assert spec == %{
         id: {:queue, queue},
+        type: :supervisor,
         start: {Honeydew.QueueSupervisor, :start_link,
                 [queue,
                  Honeydew.PollQueue, [Honeydew.EctoSource, [schema: :my_schema,
@@ -49,6 +50,7 @@ defmodule Honeydew.EctoPollQueueTest do
 
       assert spec == %{
         id: {:queue, queue},
+        type: :supervisor,
         start: {Honeydew.QueueSupervisor, :start_link,
                 [queue,
                  Honeydew.PollQueue, [Honeydew.EctoSource, [schema: :my_schema,
@@ -70,6 +72,7 @@ defmodule Honeydew.EctoPollQueueTest do
 
       assert spec == %{
         id: {:queue, queue},
+        type: :supervisor,
         start: {Honeydew.QueueSupervisor, :start_link,
                 [queue,
                  Honeydew.PollQueue, [Honeydew.EctoSource, [schema: :my_schema,

--- a/test/honeydew/ecto_poll_queue_test.exs
+++ b/test/honeydew/ecto_poll_queue_test.exs
@@ -39,9 +39,7 @@ defmodule Honeydew.EctoPollQueueTest do
                  1,
                  {Honeydew.Dispatcher.LRU, []},
                  {Abandon, []},
-                 nil, false]},
-        restart: :permanent,
-        shutdown: :infinity
+                 nil, false]}
       }
     end
 
@@ -61,9 +59,7 @@ defmodule Honeydew.EctoPollQueueTest do
                  1,
                  {Honeydew.Dispatcher.LRU, []},
                  {Abandon, []},
-                 nil, false]},
-        restart: :permanent,
-        shutdown: :infinity
+                 nil, false]}
       }
     end
 
@@ -84,9 +80,7 @@ defmodule Honeydew.EctoPollQueueTest do
                  1,
                  {Honeydew.Dispatcher.LRU, []},
                  {Abandon, []},
-                 nil, false]},
-        restart: :permanent,
-        shutdown: :infinity
+                 nil, false]}
       }
     end
 

--- a/test/honeydew_test.exs
+++ b/test/honeydew_test.exs
@@ -21,9 +21,7 @@ defmodule HoneydewTest do
       id: :my_queue_supervisor,
       start: {Honeydew.QueueSupervisor, :start_link,
               [queue, :abc, [1, 2, 3], 1, {Dis.Patcher, [:a, :b]},
-               {Abandon, []}, {Log, []}, true]},
-      restart: :permanent,
-      shutdown: :infinity
+               {Abandon, []}, {Log, []}, true]}
     }
   end
 
@@ -47,9 +45,7 @@ defmodule HoneydewTest do
       id: {:queue, queue},
       start: {Honeydew.QueueSupervisor, :start_link,
               [queue, Honeydew.Queue.ErlangQueue, [], 1,
-               {Honeydew.Dispatcher.LRU, []}, {Honeydew.FailureMode.Abandon, []}, nil, false]},
-      restart: :permanent,
-      shutdown: :infinity
+               {Honeydew.Dispatcher.LRU, []}, {Honeydew.FailureMode.Abandon, []}, nil, false]}
     }
 
     queue = {:global, :erlang.unique_integer}
@@ -59,9 +55,7 @@ defmodule HoneydewTest do
       id: {:queue, queue},
       start: {Honeydew.QueueSupervisor, :start_link,
               [queue, Honeydew.Queue.ErlangQueue, [], 1,
-               {Honeydew.Dispatcher.LRUNode, []}, {Honeydew.FailureMode.Abandon, []}, nil, false]},
-      restart: :permanent,
-      shutdown: :infinity
+               {Honeydew.Dispatcher.LRUNode, []}, {Honeydew.FailureMode.Abandon, []}, nil, false]}
     }
   end
 
@@ -78,9 +72,7 @@ defmodule HoneydewTest do
     assert spec == %{
       id: :my_worker_supervisor,
       start: {Honeydew.Workers, :start_link,
-              [queue, %{init_retry: 5, ma: {Worker, [1,2,3]}, nodes: [], num: 123, shutdown: 10000}]},
-      restart: :permanent,
-      shutdown: :infinity
+              [queue, %{init_retry: 5, ma: {Worker, [1,2,3]}, nodes: [], num: 123, shutdown: 10000}]}
     }
   end
 
@@ -92,9 +84,7 @@ defmodule HoneydewTest do
     assert spec == %{
       id: {:worker, queue},
       start: {Honeydew.Workers, :start_link,
-              [queue, %{init_retry: 5, ma: {Worker, []}, nodes: [], num: 10, shutdown: 10000}]},
-      restart: :permanent,
-      shutdown: :infinity
+              [queue, %{init_retry: 5, ma: {Worker, []}, nodes: [], num: 10, shutdown: 10000}]}
     }
   end
 

--- a/test/honeydew_test.exs
+++ b/test/honeydew_test.exs
@@ -19,6 +19,7 @@ defmodule HoneydewTest do
 
     assert spec == %{
       id: :my_queue_supervisor,
+      type: :supervisor,
       start: {Honeydew.QueueSupervisor, :start_link,
               [queue, :abc, [1, 2, 3], 1, {Dis.Patcher, [:a, :b]},
                {Abandon, []}, {Log, []}, true]}
@@ -43,6 +44,7 @@ defmodule HoneydewTest do
 
     assert spec == %{
       id: {:queue, queue},
+      type: :supervisor,
       start: {Honeydew.QueueSupervisor, :start_link,
               [queue, Honeydew.Queue.ErlangQueue, [], 1,
                {Honeydew.Dispatcher.LRU, []}, {Honeydew.FailureMode.Abandon, []}, nil, false]}
@@ -53,6 +55,7 @@ defmodule HoneydewTest do
 
     assert spec == %{
       id: {:queue, queue},
+      type: :supervisor,
       start: {Honeydew.QueueSupervisor, :start_link,
               [queue, Honeydew.Queue.ErlangQueue, [], 1,
                {Honeydew.Dispatcher.LRUNode, []}, {Honeydew.FailureMode.Abandon, []}, nil, false]}
@@ -71,6 +74,7 @@ defmodule HoneydewTest do
 
     assert spec == %{
       id: :my_worker_supervisor,
+      type: :supervisor,
       start: {Honeydew.Workers, :start_link,
               [queue, %{init_retry: 5, ma: {Worker, [1,2,3]}, nodes: [], num: 123, shutdown: 10000}]}
     }
@@ -83,6 +87,7 @@ defmodule HoneydewTest do
 
     assert spec == %{
       id: {:worker, queue},
+      type: :supervisor,
       start: {Honeydew.Workers, :start_link,
               [queue, %{init_retry: 5, ma: {Worker, []}, nodes: [], num: 10, shutdown: 10000}]}
     }

--- a/test/honeydew_test.exs
+++ b/test/honeydew_test.exs
@@ -75,20 +75,27 @@ defmodule HoneydewTest do
       init_retry_secs: 5,
       supervisor_opts: [id: :my_worker_supervisor])
 
-    assert spec == {:my_worker_supervisor,
-                    {Honeydew.Workers, :start_link,
-                     [queue, %{init_retry: 5, ma: {Worker, [1,2,3]}, nodes: [], num: 123, shutdown: 10000}]}, :permanent,
-                    :infinity, :supervisor, [Honeydew.Workers]}
+    assert spec == %{
+      id: :my_worker_supervisor,
+      start: {Honeydew.Workers, :start_link,
+              [queue, %{init_retry: 5, ma: {Worker, [1,2,3]}, nodes: [], num: 123, shutdown: 10000}]},
+      restart: :permanent,
+      shutdown: :infinity
+    }
   end
 
   test "worker_spec/2 defaults" do
     queue = :erlang.unique_integer
 
     spec =  Honeydew.worker_spec(queue, Worker)
-    assert spec == {{:worker, queue},
-                    {Honeydew.Workers, :start_link,
-                    [queue, %{init_retry: 5, ma: {Worker, []}, nodes: [], num: 10, shutdown: 10000}]}, :permanent,
-                    :infinity, :supervisor, [Honeydew.Workers]}
+
+    assert spec == %{
+      id: {:worker, queue},
+      start: {Honeydew.Workers, :start_link,
+              [queue, %{init_retry: 5, ma: {Worker, []}, nodes: [], num: 10, shutdown: 10000}]},
+      restart: :permanent,
+      shutdown: :infinity
+    }
   end
 
   test "group/1" do

--- a/test/honeydew_test.exs
+++ b/test/honeydew_test.exs
@@ -17,11 +17,14 @@ defmodule HoneydewTest do
         supervisor_opts: [id: :my_queue_supervisor],
         suspended: true)
 
-    assert spec == {:my_queue_supervisor,
-                    {Honeydew.QueueSupervisor, :start_link,
-                     [queue, :abc, [1, 2, 3], 1, {Dis.Patcher, [:a, :b]},
-                      {Abandon, []}, {Log, []}, true]}, :permanent, :infinity, :supervisor,
-                    [Honeydew.QueueSupervisor]}
+    assert spec == %{
+      id: :my_queue_supervisor,
+      start: {Honeydew.QueueSupervisor, :start_link,
+              [queue, :abc, [1, 2, 3], 1, {Dis.Patcher, [:a, :b]},
+               {Abandon, []}, {Log, []}, true]},
+      restart: :permanent,
+      shutdown: :infinity
+    }
   end
 
   test "queue_spec/2 should raise when failure/success mode args are invalid" do
@@ -40,20 +43,26 @@ defmodule HoneydewTest do
     queue = :erlang.unique_integer
     spec =  Honeydew.queue_spec(queue)
 
-    assert spec == {{:queue, queue},
-                    {Honeydew.QueueSupervisor, :start_link,
-                     [queue, Honeydew.Queue.ErlangQueue, [], 1,
-                      {Honeydew.Dispatcher.LRU, []}, {Honeydew.FailureMode.Abandon, []}, nil, false]},
-                    :permanent, :infinity, :supervisor, [Honeydew.QueueSupervisor]}
+    assert spec == %{
+      id: {:queue, queue},
+      start: {Honeydew.QueueSupervisor, :start_link,
+              [queue, Honeydew.Queue.ErlangQueue, [], 1,
+               {Honeydew.Dispatcher.LRU, []}, {Honeydew.FailureMode.Abandon, []}, nil, false]},
+      restart: :permanent,
+      shutdown: :infinity
+    }
 
     queue = {:global, :erlang.unique_integer}
     spec =  Honeydew.queue_spec(queue)
 
-    assert spec == {{:queue, queue},
-                    {Honeydew.QueueSupervisor, :start_link,
-                     [queue, Honeydew.Queue.ErlangQueue, [], 1,
-                      {Honeydew.Dispatcher.LRUNode, []}, {Honeydew.FailureMode.Abandon, []}, nil, false]},
-                    :permanent, :infinity, :supervisor, [Honeydew.QueueSupervisor]}
+    assert spec == %{
+      id: {:queue, queue},
+      start: {Honeydew.QueueSupervisor, :start_link,
+              [queue, Honeydew.Queue.ErlangQueue, [], 1,
+               {Honeydew.Dispatcher.LRUNode, []}, {Honeydew.FailureMode.Abandon, []}, nil, false]},
+      restart: :permanent,
+      shutdown: :infinity
+    }
   end
 
   test "worker_spec/2" do


### PR DESCRIPTION
When attempting to bring up Honeydew in tests via ExUnit's `start_supervised`, I receive an "old tuple-based child specification" error. 

This happens because `Honeydew.queue_spec/2` uses `Supervisor.Spec.supervisor` which is deprecated in Elixir 1.5 (see https://hexdocs.pm/elixir/Supervisor.Spec.html)

As the `mix.exs` of this package targets 1.5, I thought it would be good to update the usage

