### PR TITLE
Ignore _build and deps in ecto_poll_queue/<db name>/

### DIFF
--- a/examples/ecto_poll_queue/.gitignore
+++ b/examples/ecto_poll_queue/.gitignore
@@ -1,5 +1,5 @@
-/_build
-/deps
+/**/_build
+/**/deps
 /doc
 erl_crash.dump
 *.ez


### PR DESCRIPTION
Currently, after running the tests, are a ton of beam files showing up when running git status. This ignores those folders that become populated as a result of running the tests.