### PR TITLE
WIP: Tests for unexpected Honeydew.yield results

### DIFF
--- a/test/honeydew/failure_mode/abandon_test.exs
+++ b/test/honeydew/failure_mode/abandon_test.exs
@@ -50,4 +50,17 @@ defmodule Honeydew.FailureMode.AbandonTest do
     assert {"intentional crash", stacktrace} = reason
     assert is_list(stacktrace)
   end
+
+  test "should inform the awaiting process when the linked process terminates abnormally", %{queue: queue} do
+    {:error, reason} =
+      fn ->
+        spawn_link(fn -> raise "intentional crash" end)
+        Process.sleep(100)
+      end
+      |> Honeydew.async(queue, reply: true)
+      |> Honeydew.yield
+
+    assert {%RuntimeError{message: "intentional crash"}, stacktrace} = reason
+    assert is_list(stacktrace)
+  end
 end

--- a/test/honeydew/failure_mode/retry_test.exs
+++ b/test/honeydew/failure_mode/retry_test.exs
@@ -76,4 +76,23 @@ defmodule Honeydew.FailureMode.RetryTest do
     # job ran in the failure queue
     assert {:error, {"intentional crash", _stacktrace}} = Honeydew.yield(job)
   end
+
+  test "should inform the awaiting process when the linked process terminates abnormally", %{queue: queue, failure_queue: failure_queue} do
+    job =
+      fn ->
+        spawn_link(fn -> throw "intentional crash" end)
+        Process.sleep(100)
+      end
+      |> Honeydew.async(queue, reply: true)
+
+    assert {:retrying, {%RuntimeError{message: "intentional crash"}, _stacktrace}} = Honeydew.yield(job)
+    assert {:retrying, {%RuntimeError{message: "intentional crash"}, _stacktrace}} = Honeydew.yield(job)
+    assert {:retrying, {%RuntimeError{message: "intentional crash"}, _stacktrace}} = Honeydew.yield(job)
+    assert {:moved, {%RuntimeError{message: "intentional crash"}, _stacktrace}} = Honeydew.yield(job)
+
+    :ok = Honeydew.start_workers(failure_queue, Stateless)
+
+    # # job ran in the failure queue
+    assert {:error, {%RuntimeError{message: "intentional crash"}, _stacktrace}} = Honeydew.yield(job)
+  end
 end


### PR DESCRIPTION
I was writing these tests so I didn't accidentally change the error response format that comes back from `Honeydew.yield/1`. Unfortunately, these tests seem to reveal if a linked process dies unexpectedly, `Honeydew.yield/1` still returns `{:ok, term}`. I just wanted to double check this is a bug, not a feature before I worked on a fix.