### PR TITLE
Add tests for Honeydew.yield when job fails with uncaught throw

### DIFF
--- a/test/honeydew/failure_mode/move_test.exs
+++ b/test/honeydew/failure_mode/move_test.exs
@@ -37,7 +37,7 @@ defmodule Honeydew.FailureMode.MoveTest do
     assert Honeydew.status(failure_queue) |> get_in([:queue, :count]) == 1
   end
 
-  test "should inform the awaiting process of the error", %{queue: queue, failure_queue: failure_queue} do
+  test "should inform the awaiting process of the exception", %{queue: queue, failure_queue: failure_queue} do
     job = {:crash, [self()]} |> Honeydew.async(queue, reply: true)
 
     assert {:moved, {%RuntimeError{message: "ignore this crash"}, _stacktrace}} = Honeydew.yield(job)
@@ -46,5 +46,17 @@ defmodule Honeydew.FailureMode.MoveTest do
 
     # job ran in the failure queue
     assert {:error, {%RuntimeError{message: "ignore this crash"}, _stacktrace}} = Honeydew.yield(job)
+  end
+
+  test "should inform the awaiting process of the uncaught throw", %{queue: queue, failure_queue: failure_queue} do
+    job = fn -> throw "intentional crash" end |> Honeydew.async(queue, reply: true)
+
+    assert {:moved, {"intentional crash", stacktrace}} = Honeydew.yield(job)
+    assert is_list(stacktrace)
+
+    :ok = Honeydew.start_workers(failure_queue, Stateless)
+
+    # job ran in the failure queue
+    assert {:error, {"intentional crash", _stacktrace}} = Honeydew.yield(job)
   end
 end


### PR DESCRIPTION
This documents how Honeydew.yield returns failures when the job throws an uncaught value.