### PR TITLE
Log metadata on Worker.init or Job.run crashes

### DIFF
--- a/lib/honeydew/crash.ex
+++ b/lib/honeydew/crash.ex
@@ -1,0 +1,30 @@
+defmodule Honeydew.Crash do
+  @moduledoc false
+
+  @type type :: :exception | :throw | :bad_return_value | :exit
+
+  @type t :: %__MODULE__{
+    type: type,
+    reason: term,
+    stacktrace: Exception.stacktrace()
+  }
+
+  defstruct [:type, :reason, :stacktrace]
+
+  def new(type, reason, stacktrace)
+  def new(:exception, %{__struct__: _} = exception, stacktrace) when is_list(stacktrace) do
+    %__MODULE__{type: :exception, reason: exception, stacktrace: stacktrace}
+  end
+
+  def new(:throw, reason, stacktrace) when is_list(stacktrace) do
+    %__MODULE__{type: :throw, reason: reason, stacktrace: stacktrace}
+  end
+
+  def new(:bad_return_value, value) do
+    %__MODULE__{type: :bad_return_value, reason: value, stacktrace: []}
+  end
+
+  def new(:exit, reason) do
+    %__MODULE__{type: :exit, reason: reason, stacktrace: []}
+  end
+end

--- a/lib/honeydew/job_monitor.ex
+++ b/lib/honeydew/job_monitor.ex
@@ -1,8 +1,11 @@
 defmodule Honeydew.JobMonitor do
   use GenServer, restart: :transient
+
+  alias Honeydew.Crash
+  alias Honeydew.Queue
+
   require Logger
   require Honeydew
-  alias Honeydew.Queue
 
   # when the queue casts a job to a worker, it spawns a local JobMonitor with the job as state,
   # the JobMonitor watches the worker, if the worker dies (or its node is disconnected), the JobMonitor returns the
@@ -35,7 +38,7 @@ defmodule Honeydew.JobMonitor do
 
   def claim(job_monitor, job), do: GenServer.call(job_monitor, {:claim, job})
   def job_succeeded(job_monitor), do: GenServer.call(job_monitor, :job_succeeded)
-  def job_failed(job_monitor, reason), do: GenServer.call(job_monitor, {:job_failed, reason})
+  def job_failed(job_monitor, %Crash{} = reason), do: GenServer.call(job_monitor, {:job_failed, reason})
   def status(job_monitor), do: GenServer.call(job_monitor, :status)
   def progress(job_monitor, progress), do: GenServer.call(job_monitor, {:progress, progress})
 
@@ -82,7 +85,8 @@ defmodule Honeydew.JobMonitor do
 
   # worker died while busy
   def handle_info({:DOWN, _ref, :process, worker, reason}, %State{worker: worker} = state) do
-    execute_failure_mode(reason, state)
+    crash = Crash.new(:exit, reason)
+    execute_failure_mode(crash, state)
 
     {:stop, :normal, reset(state)}
   end
@@ -96,7 +100,17 @@ defmodule Honeydew.JobMonitor do
    %{state | job: nil, progress: :about_to_die}
   end
 
-  defp execute_failure_mode(reason, %State{job: job, failure_mode: {failure_mode, failure_mode_args}}) do
-    failure_mode.handle_failure(job, reason, failure_mode_args)
+  defp execute_failure_mode(%Crash{} = crash, %State{job: job, failure_mode: {failure_mode, failure_mode_args}}) do
+    failure_mode.handle_failure(job, format_failure_reason(crash), failure_mode_args)
   end
+
+  defp format_failure_reason(%Crash{type: :exception, reason: exception, stacktrace: stacktrace}) do
+    {exception, stacktrace}
+  end
+
+  defp format_failure_reason(%Crash{type: :throw, reason: thrown, stacktrace: stacktrace}) do
+    {thrown, stacktrace}
+  end
+
+  defp format_failure_reason(%Crash{type: :exit, reason: reason}), do: reason
 end

--- a/lib/honeydew/logger.ex
+++ b/lib/honeydew/logger.ex
@@ -1,0 +1,68 @@
+defmodule Honeydew.Logger do
+  @moduledoc false
+
+  alias Honeydew.Crash
+  alias Honeydew.Logger.Metadata
+  alias Honeydew.Job
+
+  require Logger
+
+  def worker_init_crashed(module, %Crash{type: :exception, reason: exception} = crash) do
+    Logger.warn(fn ->
+      {
+        "#{module}.init/1 must return {:ok, state :: any()}, but raised #{inspect(exception)}",
+        honeydew_crash_reason: Metadata.build_crash_reason(crash)
+      }
+    end)
+  end
+
+  def worker_init_crashed(module, %Crash{type: :throw, reason: thrown} = crash) do
+    Logger.warn(fn ->
+      {
+        "#{module}.init/1 must return {:ok, state :: any()}, but threw #{inspect(thrown)}",
+        honeydew_crash_reason: Metadata.build_crash_reason(crash)
+      }
+    end)
+  end
+
+  def worker_init_crashed(module, %Crash{type: :bad_return_value, reason: value} = crash) do
+    Logger.warn(fn ->
+      {
+        "#{module}.init/1 must return {:ok, state :: any()}, got: #{inspect value}",
+        honeydew_crash_reason: Metadata.build_crash_reason(crash)
+      }
+    end)
+  end
+
+  def job_failed(%Job{} = job, %Crash{type: :exception} = crash) do
+    Logger.warn(fn ->
+      {
+        """
+        Job failed due to exception. #{inspect(job)}
+        #{format_crash_for_log(crash)}
+        """,
+        honeydew_crash_reason: Metadata.build_crash_reason(crash)
+      }
+    end)
+  end
+
+  def job_failed(%Job{} = job, %Crash{type: :throw} = crash) do
+    Logger.warn(fn ->
+      {
+        """
+        Job failed due to uncaught throw. #{inspect job}",
+        #{format_crash_for_log(crash)}
+        """,
+        honeydew_crash_reason: Metadata.build_crash_reason(crash)
+      }
+    end)
+  end
+
+  defp format_crash_for_log(%Crash{type: :exception, reason: exception, stacktrace: stacktrace}) do
+    Exception.format(:error, exception, stacktrace)
+  end
+
+  defp format_crash_for_log(%Crash{type: :throw, reason: exception, stacktrace: stacktrace}) do
+    Exception.format(:throw, exception, stacktrace)
+  end
+end

--- a/lib/honeydew/logger/metadata.ex
+++ b/lib/honeydew/logger/metadata.ex
@@ -1,0 +1,17 @@
+defmodule Honeydew.Logger.Metadata do
+  @moduledoc false
+
+  alias Honeydew.Crash
+
+  def build_crash_reason(%Crash{type: :exception, reason: exception, stacktrace: stacktrace}) do
+    {exception, stacktrace}
+  end
+
+  def build_crash_reason(%Crash{type: :throw, reason: thrown, stacktrace: stacktrace}) do
+    {{:nocatch, thrown}, stacktrace}
+  end
+
+  def build_crash_reason(%Crash{type: :bad_return_value, reason: value, stacktrace: stacktrace}) do
+    {{:bad_return_value, value}, stacktrace}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Honeydew.Mixfile do
      elixirc_paths: elixirc_paths(Mix.env),
      description: "Pluggable local/remote job queue + worker pool with permanent workers.",
      dialyzer: [
-       plt_add_apps: [:mnesia],
+       plt_add_apps: [:mnesia, :ex_unit],
        flags: [
          # :unmatched_returns,
          # :error_handling,

--- a/test/honeydew/logger/metadata_test.exs
+++ b/test/honeydew/logger/metadata_test.exs
@@ -1,0 +1,29 @@
+defmodule Honeydew.Logger.MetadataTest do
+  use ExUnit.Case, async: true
+
+  alias Honeydew.Crash
+  alias Honeydew.Logger.Metadata
+
+  test "build_crash_reason/1 with an exception crash" do
+    exception = RuntimeError.exception("foo")
+    stacktrace = []
+    crash = Crash.new(:exception, exception, stacktrace)
+
+    assert {^exception, ^stacktrace} = Metadata.build_crash_reason(crash)
+  end
+
+  test "build_crash_reason/1 with an uncaught throw crash" do
+    thrown = :baseball
+    stacktrace = []
+    crash = Crash.new(:throw, thrown, stacktrace)
+
+    assert {{:nocatch, ^thrown}, ^stacktrace} = Metadata.build_crash_reason(crash)
+  end
+
+  test "build_crash_reason/1 with a bad return value" do
+    value = :boom
+    crash = Crash.new(:bad_return_value, value)
+
+    assert {{:bad_return_value, ^value}, []} = Metadata.build_crash_reason(crash)
+  end
+end

--- a/test/honeydew/logger_test.exs
+++ b/test/honeydew/logger_test.exs
@@ -1,0 +1,83 @@
+defmodule Honeydew.LoggerTest do
+  use ExUnit.Case, async: false
+
+  import Honeydew.CrashLoggerHelpers
+
+  alias Honeydew.Crash
+  alias Honeydew.Job
+  alias Honeydew.Logger, as: HoneydewLogger
+  alias Honeydew.Logger.Metadata
+
+  setup [:setup_echoing_error_logger]
+
+  @moduletag :capture_log
+
+  test "worker_init_crashed/1 with an exception crash" do
+    module = __MODULE__
+    error = RuntimeError.exception("foo")
+    stacktrace = []
+    crash = Crash.new(:exception, error, stacktrace)
+
+    :ok = HoneydewLogger.worker_init_crashed(module, crash)
+
+    assert_receive {:honeydew_crash_log, event}
+    assert {:warn, _, {Logger, msg, _timestamp, metadata}} = event
+    assert msg =~ ~r/#{inspect(module)}.init\/1 must return \{:ok, .* but raised #{inspect(error)}/
+    assert Keyword.fetch!(metadata, :honeydew_crash_reason) == Metadata.build_crash_reason(crash)
+  end
+
+  test "worker_init_crashed/1 with an uncaught throw crash" do
+    module = __MODULE__
+    thrown = :grenade
+    stacktrace = []
+    crash = Crash.new(:throw, thrown, stacktrace)
+
+    :ok = HoneydewLogger.worker_init_crashed(module, crash)
+
+    assert_receive {:honeydew_crash_log, event}
+    assert {:warn, _, {Logger, msg, _timestamp, metadata}} = event
+    assert msg =~ ~r/#{inspect(module)}.init\/1 must return \{:ok, .* but threw #{inspect(thrown)}/
+    assert Keyword.fetch!(metadata, :honeydew_crash_reason) == Metadata.build_crash_reason(crash)
+  end
+
+  test "worker_init_crashed/1 with a bad return value crash" do
+    module = __MODULE__
+    value = "1 million dollars"
+    crash = Crash.new(:bad_return_value, value)
+
+    :ok = HoneydewLogger.worker_init_crashed(module, crash)
+
+    assert_receive {:honeydew_crash_log, event}
+    assert {:warn, _, {Logger, msg, _timestamp, metadata}} = event
+    assert msg =~ ~r/#{inspect(module)}.init\/1 must return \{:ok, .*, got: #{inspect(value)}/
+    assert Keyword.fetch!(metadata, :honeydew_crash_reason) == Metadata.build_crash_reason(crash)
+  end
+
+  test "job_failed/1 with an exception crash" do
+    job = %Job{}
+    error = RuntimeError.exception("foo")
+    stacktrace = []
+    crash = Crash.new(:exception, error, stacktrace)
+
+    :ok = HoneydewLogger.job_failed(job, crash)
+
+    assert_receive {:honeydew_crash_log, event}
+    assert {:warn, _, {Logger, msg, _timestamp, metadata}} = event
+    assert msg =~ ~r/job failed due to exception/i
+    assert Keyword.fetch!(metadata, :honeydew_crash_reason) == Metadata.build_crash_reason(crash)
+  end
+
+  test "job_failed/1 with an uncaught throw crash" do
+    job = %Job{}
+    thrown = :grenade
+    stacktrace = []
+    crash = Crash.new(:throw, thrown, stacktrace)
+
+    :ok = HoneydewLogger.job_failed(job, crash)
+
+    assert_receive {:honeydew_crash_log, event}
+    assert {:warn, _, {Logger, msg, _timestamp, metadata}} = event
+    assert msg =~ ~r/job failed due to uncaught throw/i
+    assert Keyword.fetch!(metadata, :honeydew_crash_reason) == Metadata.build_crash_reason(crash)
+  end
+end

--- a/test/honeydew/worker_test.exs
+++ b/test/honeydew/worker_test.exs
@@ -1,8 +1,21 @@
 defmodule Honeydew.WorkerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
+
+  import Honeydew.CrashLoggerHelpers
+
+  defmodule WorkerWithBadInit do
+    @behaviour Honeydew.Worker
+    def init(:raise), do: raise "Boom"
+    def init(:throw), do: throw :boom
+    def init(:bad), do: :bad
+    def init(:ok), do: {:ok, %{}}
+  end
 
   setup [:setup_queue_name, :setup_queue, :setup_worker_pool]
 
+  @moduletag :capture_log
+
+  @tag :start_workers
   test "workers should die when their queue dies", %{queue: queue} do
     queue_pid = Honeydew.get_queue(queue)
     %{workers: workers} = Honeydew.status(queue)
@@ -16,16 +29,66 @@ defmodule Honeydew.WorkerTest do
     |> Enum.each(fn w -> assert not Process.alive?(w) end)
   end
 
+  describe "logging and exception handling" do
+    setup [:setup_echoing_error_logger]
+
+    test "when init/1 callback raises an exception", %{queue: queue} do
+      expected_error = %RuntimeError{message: "Boom"}
+      Honeydew.start_workers(queue, {WorkerWithBadInit, :raise}, num: 1)
+
+      assert_receive {:honeydew_crash_log, event}
+      assert {:warn, _, {Logger, msg, _timestamp, metadata}} = event
+      assert msg =~ ~r/#{inspect(WorkerWithBadInit)}.init\/1 must return \{:ok, .* but raised #{inspect(expected_error)}/
+      assert {^expected_error, stacktrace} = Keyword.fetch!(metadata, :honeydew_crash_reason)
+      assert is_list(stacktrace)
+    end
+
+    test "when init/1 callback throws an atom", %{queue: queue} do
+      Honeydew.start_workers(queue, {WorkerWithBadInit, :throw}, num: 1)
+
+      assert_receive {:honeydew_crash_log, event}
+      assert {:warn, _, {Logger, msg, _timestamp, metadata}} = event
+      assert msg =~ ~r/#{inspect(WorkerWithBadInit)}.init\/1 must return \{:ok, .* but threw #{inspect(:boom)}/
+      assert {{:nocatch, :boom}, stacktrace} = Keyword.fetch!(metadata, :honeydew_crash_reason)
+      assert is_list(stacktrace)
+    end
+
+    test "when init/1 callback returns a bad return value", %{queue: queue} do
+      Honeydew.start_workers(queue, {WorkerWithBadInit, :bad}, num: 1)
+
+      assert_receive {:honeydew_crash_log, event}
+      assert {:warn, _, {Logger, msg, _timestamp, metadata}} = event
+      assert msg =~ ~r/#{inspect(WorkerWithBadInit)}.init\/1 must return \{:ok, .*, got: #{inspect(:bad)}/
+      assert {{:bad_return_value, :bad}, []} = Keyword.fetch!(metadata, :honeydew_crash_reason)
+    end
+
+    test "when init/1 callback returns {:ok, state}", %{queue: queue} do
+      Honeydew.start_workers(queue, {WorkerWithBadInit, :ok}, num: 1)
+
+      refute_receive {:honeydew_crash_log, _event}
+    end
+  end
+
   defp setup_queue_name(%{queue: queue}), do: {:ok, [queue: queue]}
   defp setup_queue_name(_), do: {:ok, [queue: generate_queue_name()]}
 
   defp setup_queue(%{queue: queue}) do
     :ok = Honeydew.start_queue(queue)
+
+    on_exit fn ->
+      Honeydew.stop_queue(queue)
+    end
   end
 
-  defp setup_worker_pool(%{queue: queue}) do
+  defp setup_worker_pool(%{queue: queue, start_workers: true}) do
     :ok = Honeydew.start_workers(queue, Stateless, num: 10)
+
+    on_exit fn ->
+      Honeydew.stop_workers(queue)
+    end
   end
+
+  defp setup_worker_pool(_), do: :ok
 
   defp generate_queue_name do
     :erlang.unique_integer |> to_string

--- a/test/support/crash_logger_helpers.ex
+++ b/test/support/crash_logger_helpers.ex
@@ -1,0 +1,59 @@
+defmodule Honeydew.CrashLoggerHelpers do
+  @moduledoc """
+  Helpers for testing honeydew crash logs
+  """
+
+  import ExUnit.Callbacks
+
+  defmodule EchoingHoneydewCrashLoggerBackend do
+    @moduledoc false
+    @behaviour :gen_event
+
+    def init(_) do
+      {:ok, %{}}
+    end
+
+    def handle_call({:configure, opts}, state) do
+      target = Keyword.fetch!(opts, :target)
+      {:ok, :ok, Map.put(state, :target, target)}
+    end
+
+    def handle_event({_level, _from, {Logger, _msg, _ts, metadata}} =event, %{target: target} = state) when is_pid(target) do
+      if Keyword.has_key?(metadata, :honeydew_crash_reason) do
+        send(target, {:honeydew_crash_log, event})
+      end
+      {:ok, state}
+    end
+
+    def handle_event(_, state), do: {:ok, state}
+
+    def handle_info(_msg, state) do
+      {:ok, state}
+    end
+  end
+
+  @doc """
+  Sets up an error logger backend that sends `{:honeydew_crash_log, event}`
+  messages on any log statement that has `:honeydew_crash_reason` in its
+  metadata.
+  """
+  def setup_echoing_error_logger(_) do
+    test_pid = self()
+    Logger.add_backend(EchoingHoneydewCrashLoggerBackend, target: test_pid)
+    Logger.configure_backend(EchoingHoneydewCrashLoggerBackend, target: test_pid)
+
+    on_exit fn ->
+      Logger.remove_backend(EchoingLoggerBackend)
+      wait_backend_removal(EchoingLoggerBackend)
+    end
+  end
+
+  defp wait_backend_removal(module) do
+    if module in :gen_event.which_handlers(Logger) do
+      Process.sleep(20)
+      wait_backend_removal(module)
+    else
+      :ok
+    end
+  end
+end


### PR DESCRIPTION
This PR adds `:honeydew_crash_reason` messages to any job or worker init log messages for the purposes of allowing an error logging integration to be built. This would allow an error logger to be build like this

```elixir

defmodule MyApp.LoggerBackend do
  @moduledoc false

  @behaviour :gen_event

  def init(arg) do
    {:ok, %{}}
  end

  def handle_call({:configure, _options}, state), do: {:ok, :ok, state}

  def handle_event({_level, _pid, {Logger, msg, _timestamp, metadata}} = event, state) do
    case Keyword.fetch(metadata, :honeydew_crash_reason) do
      {:ok, crash_reason} ->
        report_error(crash_reason)
        {:ok, state}
      :error ->
        {:ok, state}
    end
  end

  def handle_event(_, state) do
    {:ok, state}
  end

  def code_change(_old_vsn, state, _extra) do
    {:ok, state}
  end

  defp report_error({%{__struct__: _} = exception, stacktrace}) do
    Honeybadger.notify(exception, %{}, stacktrace)
  end

  defp report_error({{:nocatch, thrown}, stacktrace}) do
    Honeybadger.notify(%{class: "UncaughtThrow", message: Exception.format(:throw, thrown)}, %{}, stacktrace)
  end
end
```


```elixir
defmodule MyApp.Application do
  @moduledoc false

  use Application

  alias MyApp.LoggerBackend

  def start(_type, _args) do
    Logger.add_backend(LoggerBackend)

    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
    Supervisor.start_link([], opts)
  end

  def stop(_state) do
    Logger.remove_backend(LoggerBackend)

    :ok
  end
end
```

Right now I am only exposing `:honeydew_crash_reason` (which is in the same format as Elixir 1.7's `:crash_reason` metadata). Do you think we should also add a `:honeydew_info` metadata that contains the job? I think the more I use this feature, the more I'll know what fields would be helpful. Also, maybe we document this at a later date once it's more stable?