### PR TITLE
Add lock file per env for examples/ecto_poll_queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,20 +32,18 @@ before_script:
   - MIX_ENV=test mix compile --warnings-as-errors
   - cd examples/ecto_poll_queue && MIX_ENV=cockroach mix do deps.get, compile --warnings-as-errors && cd -
   - cd examples/ecto_poll_queue && MIX_ENV=cockroach mix dialyzer --plt && cd -
-  - rm examples/ecto_poll_queue/mix.lock
   - cd examples/ecto_poll_queue && MIX_ENV=postgres  mix do deps.get, compile --warnings-as-errors && cd -
   - cd examples/ecto_poll_queue && MIX_ENV=postgres  mix dialyzer --plt && cd -
-  - rm examples/ecto_poll_queue/mix.lock
   - MIX_ENV=test mix dialyzer --plt
   - cd cockroach-v2.0.0.linux-amd64 && ./cockroach sql --insecure --host=localhost --execute "create database postgres" && cd -
   - psql -c 'create database honeydew_test;' -U postgres
+  # Check for changed files like mix.lock
+  - git diff --exit-code
 
 script:
   - mix test
-  - rm examples/ecto_poll_queue/mix.lock
   - cd examples/ecto_poll_queue && MIX_ENV=cockroach mix do deps.get && cd -
   - cd examples/ecto_poll_queue && MIX_ENV=cockroach mix dialyzer --halt-exit-status && cd -
-  - rm examples/ecto_poll_queue/mix.lock
   - cd examples/ecto_poll_queue && MIX_ENV=postgres mix do deps.get && cd -
   - cd examples/ecto_poll_queue && MIX_ENV=postgres mix dialyzer --halt-exit-status && cd -
   - MIX_ENV=test mix dialyzer --halt-exit-status

--- a/examples/ecto_poll_queue/mix.cockroach.lock
+++ b/examples/ecto_poll_queue/mix.cockroach.lock
@@ -1,0 +1,11 @@
+%{
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "db_connection": {:hex, :db_connection, "2.0.5", "ddb2ba6761a08b2bb9ca0e7d260e8f4dd39067426d835c24491a321b7f92a4da", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
+  "decimal": {:hex, :decimal, "1.6.0", "bfd84d90ff966e1f5d4370bdd3943432d8f65f07d3bab48001aebd7030590dcc", [:mix], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "3.0.7", "44dda84ac6b17bbbdeb8ac5dfef08b7da253b37a453c34ab1a98de7f7e5fec7f", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
+  "ecto_sql": {:git, "https://github.com/activeprospect/ecto_sql.git", "d10f10e6c6c47ec21bb8deb6c21a8a357e31e08d", [branch: "v3.0.5-cdb"]},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "postgrex": {:git, "https://github.com/activeprospect/postgrex.git", "c249ad706f2b4151fc3d56d874649c8ef0ae9fbe", [branch: "v0.14.1-cdb"]},
+  "telemetry": {:hex, :telemetry, "0.3.0", "099a7f3ce31e4780f971b4630a3c22ec66d22208bc090fe33a2a3a6a67754a73", [:rebar3], [], "hexpm"},
+}

--- a/examples/ecto_poll_queue/mix.exs
+++ b/examples/ecto_poll_queue/mix.exs
@@ -5,6 +5,7 @@ defmodule EctoPollQueueExample.MixProject do
     [
       app: :ecto_poll_queue_example,
       version: "0.1.0",
+      lockfile: lockfile(Mix.env()),
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
@@ -56,4 +57,9 @@ defmodule EctoPollQueueExample.MixProject do
       test: ["ecto.reset", "test"]
     ]
   end
+
+  defp lockfile(:cockroach), do: "mix.cockroach.lock"
+  defp lockfile(:postgres), do: "mix.postgres.lock"
+  defp lockfile(_), do: "mix.lock"
+
 end

--- a/examples/ecto_poll_queue/mix.postgres.lock
+++ b/examples/ecto_poll_queue/mix.postgres.lock
@@ -1,0 +1,10 @@
+%{
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "db_connection": {:hex, :db_connection, "2.0.5", "ddb2ba6761a08b2bb9ca0e7d260e8f4dd39067426d835c24491a321b7f92a4da", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
+  "decimal": {:hex, :decimal, "1.6.0", "bfd84d90ff966e1f5d4370bdd3943432d8f65f07d3bab48001aebd7030590dcc", [:mix], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "3.0.7", "44dda84ac6b17bbbdeb8ac5dfef08b7da253b37a453c34ab1a98de7f7e5fec7f", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
+  "ecto_sql": {:hex, :ecto_sql, "3.0.5", "7e44172b4f7aca4469f38d7f6a3da394dbf43a1bcf0ca975e958cb957becd74e", [:mix], [{:db_connection, "~> 2.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:ecto, "~> 3.0.6", [hex: :ecto, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.9.1", [hex: :mariaex, repo: "hexpm", optional: true]}, {:postgrex, "~> 0.14.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.3.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
+  "postgrex": {:hex, :postgrex, "0.14.1", "63247d4a5ad6b9de57a0bac5d807e1c32d41e39c04b8a4156a26c63bcd8a2e49", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.3.0", "099a7f3ce31e4780f971b4630a3c22ec66d22208bc090fe33a2a3a6a67754a73", [:rebar3], [], "hexpm"},
+}

--- a/test/honeydew/queue/ecto_poll_queue_integration_test.exs
+++ b/test/honeydew/queue/ecto_poll_queue_integration_test.exs
@@ -7,14 +7,12 @@ defmodule Honeydew.EctoPollQueueIntegrationTest do
   # Postgres
   test "ecto poll queue external project test: Postgres" do
     announce_test("Postgres (unprefixed)")
-    mix(["deps.unlock", "--all"], "postgres", prefixed: false)
     :ok = mix("deps.get", "postgres", prefixed: false)
     :ok = mix("test", "postgres", prefixed: false)
   end
 
   test "ecto poll queue external project test: Postgres (prefixed)" do
     announce_test("Postgres (prefixed)")
-    mix(["deps.unlock", "--all"], "postgres", prefixed: true)
     :ok = mix("deps.get", "postgres", prefixed: true)
     :ok = mix("test", "postgres", prefixed: true)
   end
@@ -22,7 +20,6 @@ defmodule Honeydew.EctoPollQueueIntegrationTest do
   # Cockroach
   test "ecto poll queue external project test: Cockroach" do
     announce_test("CockroachDB (unprefixed)")
-    mix(["deps.unlock", "--all"], "cockroach", prefixed: false)
     :ok = mix("deps.get", "cockroach", prefixed: false)
     :ok = mix("test", "cockroach", prefixed: false)
   end


### PR DESCRIPTION
I saw all of the places where you had to delete the`mix.lock` file for the ecto poll queue, and thought what if there were separate lock files per env? This may not be what you want, but I thought I'd just share the idea.