### PR TITLE
Delayed Jobs + Exponential Retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 /doc
 erl_crash.dump
 *.ez
-Mnesia.*
+/Mnesia.*
 .DS_Store

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 21.2.5
+erlang 21.3
 elixir 1.8.1

--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ __Plugability__
   - No forced dependency on external queue services.
 
 __Batteries Included__
-  - [In-Memory Queue](https://github.com/koudelka/honeydew/tree/master/examples/local), for fast processing of recreatable jobs.
-  - [Mnesia Queue](https://github.com/koudelka/honeydew/tree/master/examples/mnesia.exs), for persistence and simple distribution scenarios.
+  - [Mnesia Queue](https://github.com/koudelka/honeydew/tree/master/examples/mnesia.exs), for in-memory/persistence and simple distribution scenarios. (default)
   - [Ecto Queue](#ecto), to turn an Ecto schema into its own work queue, using your database.
+  - [Fast In-Memory Queue](https://github.com/koudelka/honeydew/tree/master/examples/local), for fast processing of recreatable jobs without delay requirements.
   - Can optionally heal the cluster after a disconnect or downed node when using a [Global Queue](https://github.com/koudelka/honeydew/tree/master/examples/global).
+  - [Delayed Jobs](https://github.com/koudelka/honeydew/tree/master/examples/delayed_job.exs)
+  - [Exponential Retry](https://github.com/koudelka/honeydew/tree/master/lib/honeydew/failure_mode/exponential_retry.ex), even works with Ecto queues!
+
 
 __Easy API__
   - Jobs are enqueued using `async/3` and you can receive replies with `yield/2`, somewhat like [Task](https://hexdocs.pm/elixir/Task.html).
@@ -74,7 +77,7 @@ end
 
 ### tl;dr
 - Check out the [examples](https://github.com/koudelka/honeydew/tree/master/examples).
-- Enqueue jobs with `Honeydew.async/3`.
+- Enqueue jobs with `Honeydew.async/3`, delay jobs by passing `delay_secs: <integer>`.
 - Receive responses with `Honeydew.yield/2`.
 - Emit job progress with `progress/1`
 - Queue/Worker status with `Honeydew.status/1`

--- a/README/queues.md
+++ b/README/queues.md
@@ -2,28 +2,26 @@
 Queues are the most critical location of state in Honeydew, a job will not be removed from the queue unless it has either been successfully executed, or been dealt with by the configured failure mode.
 
 Honeydew includes a few basic queue modules:
- - A simple FIFO queue implemented with the `:queue` and `Map` modules, this is the default.
  - An Mnesia queue, configurable in all the ways mnesia is, for example:
    * Run with replication (with queues running on multiple nodes)
    * Persist jobs to disk (dets)
    * Follow various safety modes ("access contexts").
+ - A fast FIFO queue implemented with the `:queue` and `Map` modules.
  - An Ecto-backed queue that automatically enqueues jobs when a new row is inserted.
 
-If you want to implement your own queue, check out the included queues as a guide. Try to keep in mind where exactly your queue state lives, is your queue process(es) where jobs live, or is it a completely stateless connector for some external broker? A mix of the two?
+If you don't explicitly specify a queue to use, Honeydew will use an in-memory Mnesia store.
 
 ### Queue Options
 There are various options you can pass to `start_queue/2`, see the [Honeydew](https://hexdocs.pm/honeydew/Honeydew.html) module docs.
 
-### Queue API Support
-|                        | async/3 + yield/2 |       filter/2     |    status/1    |     cancel/2   | suspend/1 + resume/1 |
-|------------------------|:-----------------:|:------------------:|:--------------:|:--------------:|:--------------------:|
-| ErlangQueue (`:queue`) | ✅               | ✅<sup>1</sup>      | ✅             | ✅<sup>1</sup>|  ✅                  |
-| Mnesia                 | ✅               | ✅<sup>1</sup>      | ✅<sup>1</sup> | ✅            |  ✅                  |
-| Ecto Poll Queue        | ❌               | ❌                  | ✅             | ✅<sup>2</sup>|  ✅                  |
+### API Support Differences
+|                        | async/3 + yield/2 |       filter/2     |     cancel/2   | async/3 + `delay_secs` | exponential retry |
+|------------------------|:-----------------:|:------------------:|:--------------:|:----------------------:|:-----------------:|
+| ErlangQueue (`:queue`) | ✅                | ✅<sup>1</sup>     | ✅<sup>1</sup> | ✅                     | ✅                |
+| Mnesia                 | ✅                | ✅                 | ✅             | ✅                     | ✅                |
+| Ecto Poll Queue        | ❌                | ❌                 | ✅             | ❌                     | ✅                |
 
 [1] this is "slow", O(num_job)
-
-[2] can't return `{:error, :in_progress}`, only `:ok` or `{:error, :not_found}`
 
 ### Queue Comparison
 |                        | disk-backed<sup>1</sup> | replicated<sup>2</sup> | datastore-coordinated | auto-enqueue |
@@ -37,3 +35,5 @@ There are various options you can pass to `start_queue/2`, see the [Honeydew](ht
 [2] assuming you chose a replicated database to back ecto (tested with cockroachdb and postgres).
     Mnesia replication may require manual intevention after a significant netsplit
 
+### Plugability
+If you want to implement your own queue, check out the included queues as a guide. Try to keep in mind where exactly your queue state lives, is your queue process(es) where jobs live, or is it a completely stateless connector for some external broker? A mix of the two?

--- a/examples/delayed_job.exs
+++ b/examples/delayed_job.exs
@@ -1,0 +1,22 @@
+#
+# iex -S mix run examples/delayed_job.exs
+#
+
+defmodule Worker do
+  @behaviour Honeydew.Worker
+
+  def hello(enqueued_at) do
+    secs_later = DateTime.diff(DateTime.utc_now(), enqueued_at, :millisecond) / 1_000
+    IO.puts "I was delayed by #{secs_later}s!"
+  end
+end
+
+defmodule App do
+  def start do
+    :ok = Honeydew.start_queue(:my_queue)
+    :ok = Honeydew.start_workers(:my_queue, Worker)
+  end
+end
+
+App.start
+{:hello, [DateTime.utc_now()]} |> Honeydew.async(:my_queue, delay_secs: 2)

--- a/examples/ecto_poll_queue/lib/ecto_poll_queue_example/application.ex
+++ b/examples/ecto_poll_queue/lib/ecto_poll_queue_example/application.ex
@@ -7,6 +7,7 @@ defmodule EctoPollQueueExample.Application do
 
   alias Honeydew.EctoPollQueue
   alias Honeydew.FailureMode.Retry
+  alias Honeydew.FailureMode.ExponentialRetry
   alias EctoPollQueueExample.Repo
   alias EctoPollQueueExample.Photo
   alias EctoPollQueueExample.User
@@ -21,7 +22,7 @@ defmodule EctoPollQueueExample.Application do
     opts = [strategy: :one_for_one, name: EctoPollQueueExample.Supervisor]
     {:ok, supervisor} = Supervisor.start_link(children, opts)
 
-    :ok = Honeydew.start_queue(notify_queue(), queue: {EctoPollQueue, queue_args(User)})
+    :ok = Honeydew.start_queue(notify_queue(), queue: {EctoPollQueue, queue_args(User)}, failure_mode: {ExponentialRetry, base: 3, times: 3})
     :ok = Honeydew.start_workers(notify_queue(), Notify)
 
     :ok = Honeydew.start_queue(classify_queue(), queue: {EctoPollQueue, queue_args(Photo)}, failure_mode: {Retry, [times: 1]})

--- a/examples/ecto_poll_queue/test/ecto_poll_queue_example_test.exs
+++ b/examples/ecto_poll_queue/test/ecto_poll_queue_example_test.exs
@@ -3,8 +3,11 @@ defmodule EctoPollQueueExampleTest do
   alias EctoPollQueueExample.Repo
   alias EctoPollQueueExample.Photo
   alias EctoPollQueueExample.User
-  alias Honeydew.EctoSource
   alias Honeydew.Job
+  alias Honeydew.EctoSource
+  alias Honeydew.EctoSource.State
+  alias Honeydew.PollQueue.State, as: PollQueueState
+  alias Honeydew.Queue.State, as: QueueState
 
   @moduletag :capture_log
 
@@ -34,17 +37,22 @@ defmodule EctoPollQueueExampleTest do
   end
 
   test "status/1" do
-    {:ok, _} = %User{from: self(), sleep: 2_000} |> Repo.insert()
-    {:ok, _} = %User{from: self(), sleep: 2_000} |> Repo.insert()
-    {:ok, _} = %User{from: self(), sleep: 2_000} |> Repo.insert()
+    {:ok, _} = %User{from: self(), sleep: 3_000} |> Repo.insert()
+    {:ok, _} = %User{from: self(), sleep: 3_000} |> Repo.insert()
+    {:ok, _} = %User{from: self(), sleep: 3_000} |> Repo.insert()
     {:ok, _} = %User{from: self(), should_fail: true} |> Repo.insert()
     Process.sleep(1_000)
     Honeydew.suspend(User.notify_queue())
 
-    {:ok, _} = %User{from: self(), sleep: 1_000} |> Repo.insert()
+    {:ok, _} = %User{from: self(), sleep: 3_000} |> Repo.insert()
+    {:ok, _} = %User{from: self(), sleep: 3_000} |> Repo.insert()
 
-    assert %{queue: %{abandoned: 1, count: 5, in_progress: 3}} =
-             Honeydew.status(User.notify_queue())
+    assert %{queue: %{count: 6,
+                      abandoned: 0,
+                      ready: 2,
+                      in_progress: 3,
+                      delayed: 1,
+                      stale: 0}} = Honeydew.status(User.notify_queue())
   end
 
   test "filter/2 abandoned" do
@@ -87,6 +95,30 @@ defmodule EctoPollQueueExampleTest do
     refute_receive {:notify_job_ran, ^cancel_id, 500}
   end
 
+  test "resets stale jobs" do
+    original_state = get_source_state(User.notify_queue())
+
+    update_source_state(User.notify_queue(), fn state ->
+      %State{state | stale_timeout: 0}
+    end)
+
+    {:ok, _user} = %User{from: self(), sleep: 2_000} |> Repo.insert()
+
+    Process.sleep(1_000)
+
+    assert %{queue: %{stale: 1, ready: 0}} = Honeydew.status(User.notify_queue())
+
+    User.notify_queue()
+    |> Honeydew.get_queue
+    |> send(:__reset_stale__)
+
+    assert %{queue: %{stale: 0, ready: 1}} = Honeydew.status(User.notify_queue())
+
+    update_source_state(User.notify_queue(), fn _state ->
+      original_state
+    end)
+  end
+
   test "support inter-job persistent state (retry count, etc)" do
     {:ok, %Photo{id: id}} = %Photo{from: self(), should_fail: true} |> Repo.insert()
 
@@ -111,6 +143,27 @@ defmodule EctoPollQueueExampleTest do
     assert is_nil(private)
   end
 
+  test "delay via nack" do
+    {:ok, %User{id: id}} = %User{from: self(), should_fail: true} |> Repo.insert()
+
+    delays =
+      Enum.map(0..3, fn _ ->
+        receive do
+          {:notify_job_ran, ^id} ->
+            DateTime.utc_now()
+        end
+      end)
+      |> Enum.chunk_every(2, 1, :discard)
+      |> Enum.map(fn [a, b] -> DateTime.diff(b, a) end)
+
+    # 3^0 - 1 -> 0 sec delay
+    # 3^1 - 1 -> 2 sec delay
+    # 3^2 - 1 -> 8 sec delay
+    assert_in_delta Enum.at(delays, 0), 0, 1
+    assert_in_delta Enum.at(delays, 1), 2, 1
+    assert_in_delta Enum.at(delays, 2), 8, 1
+  end
+
   test "hammer" do
     ids =
       Enum.map(1..2_000, fn _ ->
@@ -123,5 +176,24 @@ defmodule EctoPollQueueExampleTest do
     end)
 
     refute_receive({:classify_job_ran, _}, 200)
+  end
+
+  defp get_source_state(queue) do
+    %QueueState{private: %PollQueueState{source: {EctoSource, state}}} =
+      queue
+      |> Honeydew.get_queue()
+      |> :sys.get_state
+
+    state
+  end
+
+  defp update_source_state(queue, state_fn) do
+    queue
+    |> Honeydew.get_queue()
+    |> :sys.replace_state(fn %QueueState{private: %PollQueueState{source: {EctoSource, state}} = poll_queue_state} = queue_state ->
+      %QueueState{queue_state |
+                  private: %PollQueueState{poll_queue_state |
+                                           source: {EctoSource, state_fn.(state)}}}
+    end)
   end
 end

--- a/examples/exponential_retry.exs
+++ b/examples/exponential_retry.exs
@@ -1,0 +1,26 @@
+#
+# iex -S mix run examples/exponential_retry.exs
+#
+
+defmodule Worker do
+  @behaviour Honeydew.Worker
+
+  def crash(enqueued_at) do
+    secs_later = DateTime.diff(DateTime.utc_now(), enqueued_at, :millisecond) / 1_000
+    IO.puts "I ran #{secs_later}s after enqueue!"
+    raise "crashing on purpose!"
+  end
+end
+
+defmodule App do
+  alias Honeydew.FailureMode.ExponentialRetry
+
+  def start do
+    :ok = Honeydew.start_queue(:my_queue, failure_mode: {ExponentialRetry, [times: 5]})
+    :ok = Honeydew.start_workers(:my_queue, Worker)
+  end
+end
+
+App.start
+Logger.configure(level: :error) # don't fill the console with crash reports
+{:crash, [DateTime.utc_now()]} |> Honeydew.async(:my_queue, delay_secs: 1)

--- a/examples/filter_and_cancel.exs
+++ b/examples/filter_and_cancel.exs
@@ -34,10 +34,7 @@ Honeydew.status(:my_queue)
 # find the job that would run with the argument `10`, as it wont have started yet
 # and cancel it
 :ok =
-  Honeydew.filter(:my_queue, fn
-    %Honeydew.Job{task: {:run, [10]}} -> true
-    _ -> false
-  end)
+  Honeydew.filter(:my_queue, %{task: {:run, [10]}})
   |> List.first
   |> Honeydew.cancel
 

--- a/examples/mnesia.exs
+++ b/examples/mnesia.exs
@@ -1,0 +1,22 @@
+#
+# iex -S mix run examples/mnesia.exs
+#
+
+defmodule Worker do
+  @behaviour Honeydew.Worker
+
+  def hello(thing) do
+    IO.puts "Hello #{thing}!"
+  end
+end
+
+defmodule App do
+  def start do
+    nodes = [node()]
+    :ok = Honeydew.start_queue(:my_queue, queue: {Honeydew.Queue.Mnesia, [disc_copies: nodes]})
+    :ok = Honeydew.start_workers(:my_queue, Worker)
+  end
+end
+
+App.start
+{:hello, ["World"]} |> Honeydew.async(:my_queue)

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -187,9 +187,11 @@ defmodule Honeydew do
 
   Filter jobs with a specific task.
 
-      Honeydew.filter(:my_queue, &match?(%Honeydew.Job{task: {:ping, _}}, &1))
+      Honeydew.filter(:my_queue, &match?(%Honeydew.Job{task: {:ping, _}}, &1)) # ErlangQueue or Mnesia
 
-      Honeydew.filter(:my_queue, :abandoned)
+      Honeydew.filter(:my_queue, %{task: {:ping, ["127.0.0.1"]}}) # Mnesia
+
+      Honeydew.filter(:my_queue, :abandoned) # Ecto queue
 
   Return all jobs.
 

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -212,8 +212,7 @@ defmodule Honeydew do
 
   * `:ok` - Job had not been started and was able to be cancelled.
   * `{:error, :in_progress}` - Job was in progress and unable to be cancelled.
-  * `{:error, :not_found}` - Job was not found on the queue (or already
-      processed) and was unable to be cancelled.
+  * `{:error, :not_found}` - Job was not found on the queue (or already processed) and was unable to be cancelled.
   """
   @spec cancel(Job.t) :: :ok | {:error, :in_progress} | {:error, :not_found}
   def cancel(%Job{queue: queue} = job) do
@@ -231,8 +230,7 @@ defmodule Honeydew do
 
   * `:ok` - Job had not been started and was able to be cancelled.
   * `{:error, :in_progress}` - Job was in progress and unable to be cancelled, the Ecto Poll Queue does not support this return.
-  * `{:error, :not_found}` - Job was not found on the queue (or already
-  processed) and was unable to be cancelled.
+  * `{:error, :not_found}` - Job was not found on the queue (or already processed) and was unable to be cancelled.
   """
   @spec cancel(Job.private(), queue_name) :: :ok | {:error, :in_progress} | {:error, :not_found}
   def cancel(private, queue) do

--- a/lib/honeydew/failure_mode/exponential_retry.ex
+++ b/lib/honeydew/failure_mode/exponential_retry.ex
@@ -1,0 +1,78 @@
+defmodule Honeydew.FailureMode.ExponentialRetry do
+  alias Honeydew.Job
+  alias Honeydew.FailureMode.Retry
+  alias Honeydew.FailureMode.Move
+
+  @moduledoc """
+  Instructs Honeydew to retry a job a number of times on failure, waiting an exponentially growing number
+  of seconds between retry attempts. You may specify the base of exponential delay with the `:base` argument,
+  it defaults to 2.
+
+  Please note, this failure mode will not work with the ErlangQueue queue implementation at the moment.
+
+  ## Examples
+
+  Retry jobs in this queue 3 times, delaying exponentially between with a base of 2:
+
+  ```elixir
+  Honeydew.start_queue(:my_queue, failure_mode: {#{inspect __MODULE__},
+                                                 times: 3,
+                                                 base: 2})
+  ```
+
+  Retry jobs in this queue 3 times, delaying exponentially between with a base of 2, and then move to another queue:
+
+  ```elixir
+  Honeydew.start_queue(:my_queue,
+                       failure_mode: {#{inspect __MODULE__},
+                                      times: 3,
+                                      base: 2,
+                                      finally: {#{inspect Move},
+                                                queue: :dead_letters}})
+  ```
+  """
+
+  require Logger
+
+  @behaviour Honeydew.FailureMode
+
+  @impl true
+  def validate_args!(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> validate_args!
+  end
+
+  def validate_args!(%{base: base}) when not is_integer(base) or base <= 0 do
+    raise ArgumentError, "You provided a bad `:base` argument (#{inspect base}) to the ExponentialRetry failure mode, it's expecting a positive number."
+  end
+
+  def validate_args!(args), do: Retry.validate_args!(args, __MODULE__)
+
+  @impl true
+  def handle_failure(job, reason, args) do
+    args =
+      args
+      |> Keyword.put(:fun, &exponential/3)
+      |> Keyword.put_new(:base, 2)
+
+    Retry.handle_failure(job, reason, args)
+  end
+
+  #
+  # base ^ times_retried - 1, rounded to integer
+  #
+
+  def exponential(%Job{failure_private: nil} = job, reason, args) do
+    exponential(%Job{job | failure_private: 0}, reason, args)
+  end
+
+  def exponential(%Job{failure_private: times_retried} = job, reason, %{times: max_retries, base: base}) when times_retried < max_retries do
+    delay_secs = (:math.pow(base, times_retried) - 1) |> round()
+
+    Logger.info "Job failed because #{inspect reason}, retrying #{max_retries - times_retried} more times, next attempt in #{delay_secs}s, job: #{inspect job}"
+
+    {:cont, times_retried + 1, delay_secs}
+  end
+  def exponential(_, _, _), do: :halt
+end

--- a/lib/honeydew/failure_mode/retry.ex
+++ b/lib/honeydew/failure_mode/retry.ex
@@ -1,7 +1,11 @@
 defmodule Honeydew.FailureMode.Retry do
+  alias Honeydew.Job
+  alias Honeydew.Queue
+  alias Honeydew.FailureMode.Abandon
   alias Honeydew.FailureMode.Move
+
   @moduledoc """
-  Instructs Honeydew to retry a job `x` times on failure.
+  Instructs Honeydew to retry a job a number of times on failure.
 
   ## Examples
 
@@ -22,48 +26,76 @@ defmodule Honeydew.FailureMode.Retry do
                                                 queue: :dead_letters}})
   ```
   """
-  alias Honeydew.Job
-  alias Honeydew.Queue
-  alias Honeydew.FailureMode.Abandon
-
   require Logger
 
   @behaviour Honeydew.FailureMode
 
   @impl true
-  # if everything looks right, validate the 'finally' mode args, too
-  def validate_args!([times: times, finally: {module, args}]) when is_integer(times)
-                                                               and times > 0
-                                                               and is_atom(module)
-                                                               and is_list(args) do
-    module.validate_args!(args)
+  def validate_args!(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> validate_args!(__MODULE__)
   end
 
-  def validate_args!([times: times]) when is_integer(times) and times > 0, do: :ok
-  def validate_args!(args), do: raise ArgumentError, "You provided arguments (#{inspect args}) to the Retry failure mode, it's expecting either [times: times] or [times: times, finally: {module, args}]"
+  def validate_args!(args, module \\ __MODULE__)
+
+  def validate_args!(%{fun: fun}, _module) when is_function(fun, 3), do: :ok
+  def validate_args!(%{fun: bad}, module) do
+    raise ArgumentError, "You provided a bad `:fun` argument (#{inspect bad}) to the #{module} failure mode, it's expecting a function or function capture of arity three (job, failure_reason, args), for example: `&#{inspect __MODULE__}.immediate/3`"
+  end
+
+  def validate_args!(%{times: times}, module) when not is_integer(times) or times <= 0 do
+    raise ArgumentError, "You provided a bad `:times` argument (#{inspect times}) to the #{module} failure mode, it's expecting a positive integer."
+  end
+
+  def validate_args!(%{finally: {module, args} = bad}, module) when not is_atom(module) or not is_list(args) do
+    raise ArgumentError, "You provided a bad `:finally` argument (#{inspect bad}) to the #{module} failure mode, it's expecting `finally: {module, args}`"
+  end
+
+  def validate_args!(%{times: _times, finally: {m, a}}, _module) do
+    m.validate_args!(a)
+  end
+
+  def validate_args!(%{times: _times}, _module), do: :ok
+
+  def validate_args!(bad, module) do
+    raise ArgumentError, "You provided bad arguments (#{inspect bad}) to the #{module} failure mode, at a minimum, it must be a list with a maximum number of retries specified, for example: `[times: 5]`"
+  end
+
 
   @impl true
-  def handle_failure(job, reason, [times: times]), do:
-    handle_failure(job, reason, [times: times, finally: {Abandon, []}])
+  def handle_failure(%Job{queue: queue, from: from} = job, reason, args) when is_list(args) do
+    args = Enum.into(args, %{})
+    args = Map.merge(%{finally: {Abandon, []},
+                       fun: &immediate/3}, args)
 
-  def handle_failure(%Job{failure_private: nil} = job, reason, [times: times, finally: finally]), do:
-    handle_failure(%{job | failure_private: times}, reason, finally)
+    %{fun: fun, finally: {finally_module, finally_args}} = args
 
-  def handle_failure(%Job{failure_private: 0} = job, reason, [times: _times, finally: {final_mode, final_args}]), do:
-    final_mode.handle_failure(%{job | failure_private: nil}, reason, final_args)
+    case fun.(job, reason, args) do
+      {:cont, private, delay_secs} ->
+        job = %Job{job | failure_private: private, delay_secs: delay_secs, result: {:retrying, reason}}
 
-  def handle_failure(%Job{queue: queue, from: from, failure_private: tries_left} = job, reason, _args) do
-    tries_left = tries_left - 1
-    job = %{job | failure_private: tries_left}
+        queue
+        |> Honeydew.get_queue
+        |> Queue.nack(job)
 
-    Logger.info "Job failed because #{inspect reason}, retrying #{tries_left} more times, job: #{inspect job}"
+        # send the error to the awaiting process, if necessary
+        with {owner, _ref} <- from,
+          do: send(owner, %{job | result: {:retrying, reason}})
 
-    queue
-    |> Honeydew.get_queue
-    |> Queue.nack(job)
-
-    # send the error to the awaiting process, if necessary
-    with {owner, _ref} <- from,
-      do: send(owner, %{job | result: {:retrying, reason}})
+      :halt ->
+        finally_module.handle_failure(%{job | failure_private: nil, delay_secs: 0}, reason, finally_args)
+    end
   end
+
+  def immediate(%Job{failure_private: nil} = job, reason, args) do
+    immediate(%Job{job | failure_private: 0}, reason, args)
+  end
+
+  def immediate(%Job{failure_private: times_retried} = job, reason, %{times: max_retries}) when times_retried < max_retries do
+    Logger.info "Job failed because #{inspect reason}, retrying #{max_retries - times_retried} more times, job: #{inspect job}"
+
+    {:cont, times_retried + 1, 0}
+  end
+  def immediate(_, _, _), do: :halt
 end

--- a/lib/honeydew/job.ex
+++ b/lib/honeydew/job.ex
@@ -15,12 +15,14 @@ defmodule Honeydew.Job do
              :job_monitor,
              :enqueued_at,
              :started_at,
-             :completed_at]
+             :completed_at,
+             {:delay_secs, 0}]
 
   @type t :: %__MODULE__{
-    task: Honeydew.task | nil,
+    task: Honeydew.task,
     queue: Honeydew.queue_name,
-    private: private
+    private: private,
+    delay_secs: integer()
   }
 
   @doc false

--- a/lib/honeydew/job.ex
+++ b/lib/honeydew/job.ex
@@ -3,29 +3,19 @@ defmodule Honeydew.Job do
   A Honeydew job.
   """
 
-  require Record
-
   @type private :: term()
 
-  # :private needs to be first, the mnesia queue's ordering depends on it
-  @fields [:private, # queue's private state
-           :failure_private, # failure mode's private state
-           :task,
-           :from, # if the requester wants the result, here's where to send it
-           :result,
-           :by, # node last processed the job
-           :queue,
-           :job_monitor,
-           :enqueued_at,
-           :started_at,
-           :completed_at]
-
-  @kv Enum.map(@fields, &{&1, nil})
-
-  defstruct @kv
-  @doc false
-  Record.defrecord :job, @kv
-  @match_spec @fields |> Enum.map(&{&1, :_}) |> Enum.into(%{})
+  defstruct [:private, # queue's private state
+             :failure_private, # failure mode's private state
+             :task,
+             :from, # if the requester wants the result, here's where to send it
+             :result,
+             :by, # node last processed the job
+             :queue,
+             :job_monitor,
+             :enqueued_at,
+             :started_at,
+             :completed_at]
 
   @type t :: %__MODULE__{
     task: Honeydew.task | nil,
@@ -34,40 +24,7 @@ defmodule Honeydew.Job do
   }
 
   @doc false
-  def fields, do: @fields
-
-  vars = @fields |> Enum.map(&Macro.var(&1, __MODULE__))
-  vars_keyword_list = Enum.zip(@fields, vars)
-
-  @doc false
   def new(task, queue) do
     %__MODULE__{task: task, queue: queue, enqueued_at: System.system_time(:millisecond)}
-  end
-
-  @doc false
-  def to_record(%{unquote_splicing(vars_keyword_list)}, name) do
-    {name, unquote_splicing(vars)}
-  end
-
-  @doc false
-  def to_record({_name, unquote_splicing(vars)}, name) do
-    {name, unquote_splicing(vars)}
-  end
-
-  @doc false
-  def to_record({_name, unquote_splicing(vars)}) do
-    {:job, unquote_splicing(vars)}
-  end
-
-  @doc false
-  def from_record({_name, unquote_splicing(vars)}) do
-    %__MODULE__{unquote_splicing(vars_keyword_list)}
-  end
-
-  @doc false
-  def match_spec(map, name) do
-    @match_spec
-    |> Map.merge(map)
-    |> Honeydew.Job.to_record(name)
   end
 end

--- a/lib/honeydew/job.ex
+++ b/lib/honeydew/job.ex
@@ -19,7 +19,7 @@ defmodule Honeydew.Job do
              {:delay_secs, 0}]
 
   @type t :: %__MODULE__{
-    task: Honeydew.task,
+    task: Honeydew.task | nil,
     queue: Honeydew.queue_name,
     private: private,
     delay_secs: integer()

--- a/lib/honeydew/queue/erlang_queue.ex
+++ b/lib/honeydew/queue/erlang_queue.ex
@@ -71,7 +71,6 @@ defmodule Honeydew.Queue.ErlangQueue do
   end
 
   @impl true
-  @spec cancel(Job.t, Queue.private) :: {:ok | {:error, :in_progress | :not_found}, Queue.private}
   def cancel(%Job{private: private}, {pending, in_progress}) do
     filter = fn
       %Job{private: ^private} -> false;

--- a/lib/honeydew/queue/mnesia.ex
+++ b/lib/honeydew/queue/mnesia.ex
@@ -202,7 +202,6 @@ defmodule Honeydew.Queue.Mnesia do
   end
 
   @impl true
-  @spec cancel(Job.t, Queue.private) :: {:ok | {:error, :in_progress | :not_found}, Queue.private}
   def cancel(%Job{private: id}, %PState{table: table, in_progress_table: in_progress_table, access_context: access_context} = state) do
     reply =
       :mnesia.activity(access_context, fn ->

--- a/lib/honeydew/queue/mnesia/wrapped_job.ex
+++ b/lib/honeydew/queue/mnesia/wrapped_job.ex
@@ -1,0 +1,84 @@
+defmodule Honeydew.Queue.Mnesia.WrappedJob do
+  alias Honeydew.Job
+
+  @record_name :wrapped_job
+  @record_fields [:key, :job]
+
+  job_filter_map =
+    %Job{}
+    |> Map.from_struct()
+    |> Enum.map(fn {k, _} ->
+      {k, :_}
+    end)
+
+  @job_filter struct(Job, job_filter_map)
+
+  defstruct [:run_at,
+             :id,
+             :job]
+
+  def record_name, do: @record_name
+  def record_fields, do: @record_fields
+
+  def new(%Job{delay_secs: delay_secs} = job) do
+    id = :erlang.unique_integer()
+    run_at = now() + delay_secs
+
+    job = %{job | private: key(run_at, id)}
+
+    %__MODULE__{run_at: run_at,
+                id: id,
+                job: job}
+  end
+
+  def from_record({@record_name, {run_at, id}, job}) do
+    %__MODULE__{run_at: run_at,
+                id: id,
+                job: job}
+  end
+
+  def to_record(%__MODULE__{run_at: run_at,
+                            id: id,
+                            job: job}) do
+    {@record_name, key(run_at, id), job}
+  end
+
+  def key({@record_name, key, _job}) do
+    key
+  end
+
+  def key(run_at, id) do
+    {run_at, id}
+  end
+
+  def filter_pattern(map) do
+    job = struct(@job_filter, map)
+
+    %__MODULE__{
+      id: :_,
+      run_at: :_,
+      job: job
+    }
+    |> to_record
+  end
+
+  def reserve_match_spec do
+    pattern =
+      %__MODULE__{
+        id: :_,
+        run_at: :"$1",
+        job: :_
+      }
+      |> to_record
+
+    [{
+      pattern,
+      [{:"=<", :"$1", now()}],
+      [:"$_"]
+    }]
+  end
+
+  defp now do
+    :erlang.monotonic_time(:second)
+  end
+end

--- a/lib/honeydew/queue/mnesia/wrapped_job.ex
+++ b/lib/honeydew/queue/mnesia/wrapped_job.ex
@@ -24,7 +24,7 @@ defmodule Honeydew.Queue.Mnesia.WrappedJob do
     id = :erlang.unique_integer()
     run_at = now() + delay_secs
 
-    job = %{job | private: key(run_at, id)}
+    job = %{job | private: id}
 
     %__MODULE__{run_at: run_at,
                 id: id,
@@ -49,6 +49,19 @@ defmodule Honeydew.Queue.Mnesia.WrappedJob do
 
   def key(run_at, id) do
     {run_at, id}
+  end
+
+  def id_from_key({_run_at, id}) do
+    id
+  end
+
+  def id_pattern(id) do
+    %__MODULE__{
+      id: id,
+      run_at: :_,
+      job: :_
+    }
+    |> to_record
   end
 
   def filter_pattern(map) do

--- a/lib/honeydew/queues.ex
+++ b/lib/honeydew/queues.ex
@@ -3,7 +3,7 @@ defmodule Honeydew.Queues do
 
   use Supervisor
   alias Honeydew.Queue
-  alias Honeydew.Queue.ErlangQueue
+  alias Honeydew.Queue.Mnesia
   alias Honeydew.Dispatcher.LRUNode
   alias Honeydew.Dispatcher.LRU
   alias Honeydew.FailureMode.Abandon
@@ -30,7 +30,7 @@ defmodule Honeydew.Queues do
   def start_queue(name, opts) do
     {module, args} =
       case opts[:queue] do
-        nil -> {ErlangQueue, []}
+        nil -> {Mnesia, [ram_copies: [node()]]}
         module when is_atom(module) -> {module, []}
         {module, args} -> {module, args}
       end

--- a/lib/honeydew/sources/ecto/sql.ex
+++ b/lib/honeydew/sources/ecto/sql.ex
@@ -21,8 +21,10 @@ defmodule Honeydew.EctoSource.SQL do
   @callback reserve(State.t()) :: sql
   @callback cancel(State.t()) :: sql
   @callback ready :: sql
+  @callback delay_ready(State.t()) :: sql
   @callback status(State.t()) :: sql
   @callback filter(State.t(), filter) :: sql
+  @callback reset_stale(State.t()) :: sql
   @callback table_name(module()) :: String.t()
 
   @spec module(repo, override) :: sql_module | no_return

--- a/lib/honeydew/sources/ecto/sql/cockroach.ex
+++ b/lib/honeydew/sources/ecto/sql/cockroach.ex
@@ -25,10 +25,18 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     @impl true
+    def delay_ready(state) do
+      "UPDATE #{state.table}
+      SET #{state.lock_field} = (#{ready()} + $1 * 1000),
+          #{state.private_field} = $2
+      WHERE #{state.key_field} = $3"
+    end
+
+    @impl true
     def reserve(state) do
       "UPDATE #{state.table}
-      SET #{state.lock_field} = #{now_msecs()}
-      WHERE #{state.lock_field} BETWEEN 0 AND #{msecs_ago(state.stale_timeout)}
+      SET #{state.lock_field} = #{reserve_at(state)}
+      WHERE #{state.lock_field} BETWEEN 0 AND #{ready()}
       ORDER BY #{state.lock_field}, #{state.key_field}
       LIMIT 1
       RETURNING #{state.key_field}, #{state.private_field}"
@@ -40,15 +48,31 @@ if Code.ensure_loaded?(Ecto) do
       SET #{state.lock_field} = NULL
       WHERE
         id = $1
-        AND #{state.lock_field} BETWEEN 0 AND #{msecs_ago(state.stale_timeout)}
       RETURNING #{state.lock_field}"
     end
+
 
     @impl true
     def status(state) do
       "SELECT COUNT(IF(#{state.lock_field} IS NOT NULL, 1, NULL)) AS count,
-              COUNT(IF(#{state.lock_field} >= #{msecs_ago(state.stale_timeout)}, 1, NULL)) AS in_progress,
-              COUNT(IF(#{state.lock_field} = #{EctoSource.abandoned()}, 1, NULL)) AS abandoned
+
+              COUNT(IF(#{state.lock_field} = #{EctoSource.abandoned()}, 1, NULL)) AS abandoned,
+
+              COUNT(IF(
+                0 <= #{state.lock_field} AND #{state.lock_field} <= #{ready()},
+              1, NULL)) AS ready,
+
+              COUNT(IF(
+                #{ready()} < #{state.lock_field} AND #{state.lock_field} < #{stale_at()},
+              1, NULL)) AS delayed,
+
+              COUNT(IF(
+                #{stale_at()} < #{state.lock_field} AND #{state.lock_field} < #{now()},
+              1, NULL)) AS stale,
+
+              COUNT(IF(
+                #{now()} < #{state.lock_field} AND #{state.lock_field} <= #{reserve_at(state)},
+              1, NULL)) AS in_progress
       FROM #{state.table}"
     end
 
@@ -57,11 +81,31 @@ if Code.ensure_loaded?(Ecto) do
       "SELECT id FROM #{state.table} WHERE #{state.lock_field} = #{EctoSource.abandoned()}"
     end
 
-    defp msecs_ago(msecs) do
-      "#{now_msecs()} - #{msecs}"
+    @impl true
+    def reset_stale(state) do
+      "UPDATE #{state.table}
+       SET #{state.lock_field} = DEFAULT,
+           #{state.private_field} = DEFAULT
+       WHERE
+         #{stale_at()} < #{state.lock_field}
+         AND
+         #{state.lock_field} < #{now()}"
     end
 
-    defp now_msecs do
+    defp reserve_at(state) do
+      "#{now()} + #{state.stale_timeout}"
+    end
+
+    defp stale_at do
+      "(NOW() - INTERVAL '5 year')"
+      |> time_in_msecs
+    end
+
+    defp msecs_ago(msecs) do
+      "#{now()} - #{msecs}"
+    end
+
+    defp now do
       time_in_msecs("NOW()")
     end
 

--- a/lib/honeydew/sources/ecto/state.ex
+++ b/lib/honeydew/sources/ecto/state.ex
@@ -12,6 +12,7 @@ defmodule Honeydew.EctoSource.State do
     :task_fn,
     :queue,
     :stale_timeout,
+    :reset_stale_interval
   ]
 
   @type stale_timeout :: pos_integer
@@ -25,5 +26,6 @@ defmodule Honeydew.EctoSource.State do
                          private_field: String.t(),
                          stale_timeout: stale_timeout,
                          task_fn: function(),
-                         queue: Honeydew.queue_name()}
+                         queue: Honeydew.queue_name(),
+                         reset_stale_interval: pos_integer()}
 end

--- a/lib/honeydew/sources/ecto_source.ex
+++ b/lib/honeydew/sources/ecto_source.ex
@@ -6,23 +6,22 @@
 #  1. Acts as a lock, to ensure that only one worker is processing the job at a time, no matter how many nodes are running
 #     copies of the queue. It expires after a configurable period of time (the queue process or entire node crashed).
 #  2. Indicates the status of the job, it can be either:
-#     - "ready", between zero and the beginning of the stale window
-#     - "in progress", inside of the stale window
+#     - "ready", between zero and SQL.ready()
+#     - "delayed", between SQL.ready() and the beginning of the stale window
+#     - "in progress", from now until now + stale_timeout
+#     - "stale", within a year ago ago from now
 #     - "abandoned", -1
 #     - "finished", nil
 #  3. Indicate the order in which jobs should be processed.
 #
-#
-#
 #      unix epoch zero
-#             |<--------------------- ready --------------------------->|
-#             v                                                         |
-# time <------0---------------|----------------------------|------------|-------|--->
-#            ^                ^                            ^            ^       ^
-#       abandoned(-1)      new jobs                 far_in_the_past    stale   now
-#                     (now - far_in_the_past)
-#
-#
+#             |<-------- ~ 24+ yrs ------->|<----- ~ 18 yrs ---->|<--- 5 yrs -->|<------- stale_timeout ------->|
+#             |<---------- ready ----------|<------ delayed -----|              |                               |
+#             |                            |                     |<--- stale ---|<-------- in progress ---------|
+# time -------0----------------------------|------------------------------------|-------------------------------|---->
+#            ^                             ^                                    ^                               ^
+#       abandoned(-1)                  SQL.ready()                             now                           reserve()
+#                                 now - far_in_the_past()                                              now + stale_timeout
 #
 # The private field is a simple binary field that contains an erlang term, it's used for data that needs to be
 # persisted between job attempts, specificaly, it's the "failure_private" contents of the job.
@@ -31,7 +30,7 @@
 # As the main objective is to minimize disruption, I wanted the default values for the additional fields to be set
 # statically in the migration, rather than possibly interfering with the user's schema validations on save etc...
 # The only runtime configuration the user should set is the `stale_timeout`, which should be the maximum expected
-# time that a job will take.
+# time that a job will take until it should be retried.
 #
 
 #
@@ -44,9 +43,13 @@ if Code.ensure_loaded?(Ecto) do
     require Logger
     alias Honeydew.Job
     alias Honeydew.PollQueue
+    alias Honeydew.PollQueue.State, as: PollQueueState
     alias Honeydew.EctoSource.State
+    alias Honeydew.Queue.State, as: QueueState
 
     @behaviour PollQueue
+
+    @reset_stale_interval 5 * 60 * 1_000 # five minutes in msecs
 
     @abandoned -1
     def abandoned, do: @abandoned
@@ -57,6 +60,7 @@ if Code.ensure_loaded?(Ecto) do
       repo = Keyword.fetch!(args, :repo)
       sql = Keyword.fetch!(args, :sql)
       stale_timeout = args[:stale_timeout] * 1_000
+      reset_stale_interval = @reset_stale_interval # held in state so tests can change it
 
       table = sql.table_name(schema)
 
@@ -71,6 +75,8 @@ if Code.ensure_loaded?(Ecto) do
              fn(id, _queue) -> {:run, [id]} end
            end
 
+      reset_stale(reset_stale_interval)
+
       {:ok, %State{schema: schema,
                    repo: repo,
                    sql: sql,
@@ -80,7 +86,8 @@ if Code.ensure_loaded?(Ecto) do
                    private_field: field_name(queue, :private),
                    task_fn: task_fn,
                    queue: queue,
-                   stale_timeout: stale_timeout}}
+                   stale_timeout: stale_timeout,
+                   reset_stale_interval: reset_stale_interval}}
     end
 
     # lock a row for processing
@@ -128,8 +135,20 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     @impl true
-    def nack(%Job{private: id, failure_private: private}, state) do
-      finalize(id, 1, private, state)
+    def nack(%Job{private: id, failure_private: private, delay_secs: delay_secs}, %State{sql: sql,
+                                                                                         repo: repo,
+                                                                                         schema: schema,
+                                                                                         key_field: key_field,
+                                                                                         private_field: private_field} = state) do
+      {:ok, id} = dump_field(schema, repo, key_field, id)
+      {:ok, private} = dump_field(schema, repo, private_field, private)
+
+      {:ok, %{num_rows: 1}} =
+        state
+        |> sql.delay_ready
+        |> repo.query([delay_secs, private, id])
+
+      state
     end
 
     @impl true
@@ -149,12 +168,15 @@ if Code.ensure_loaded?(Ecto) do
 
     @impl true
     def status(%State{repo: repo, sql: sql} = state) do
-      {:ok, %{num_rows: 1, rows: [[count, in_progress, abandoned]]}} =
+      {:ok, %{num_rows: 1, columns: columns, rows: [values]}} =
         state
         |> sql.status
         |> repo.query([])
 
-      %{count: count, in_progress: in_progress, abandoned: abandoned}
+      columns
+      |> Enum.map(&String.to_atom/1)
+      |> Enum.zip(values)
+      |> Enum.into(%{})
     end
 
     @impl true
@@ -172,6 +194,19 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     @impl true
+    def handle_info(:__reset_stale__, %QueueState{private: %PollQueueState{source: {__MODULE__, %State{sql: sql,
+                                                                                                       repo: repo,
+                                                                                                       reset_stale_interval: reset_stale_interval} = state}}} = queue_state) do
+      {:ok, _} =
+        state
+        |> sql.reset_stale
+        |> repo.query([])
+
+      reset_stale(reset_stale_interval)
+
+      {:noreply, queue_state}
+    end
+
     def handle_info(msg, queue_state) do
       Logger.warn("[Honeydew] Queue #{inspect(self())} received unexpected message #{inspect(msg)}")
 
@@ -180,6 +215,10 @@ if Code.ensure_loaded?(Ecto) do
 
     def field_name(queue, name) do
       :"honeydew_#{Honeydew.table_name(queue)}_#{name}"
+    end
+
+    defp reset_stale(reset_stale_interval) do
+      {:ok, _} = :timer.send_after(reset_stale_interval, :__reset_stale__)
     end
 
     defp finalize(id, lock, private, state) do

--- a/test/hammer/hammer.exs
+++ b/test/hammer/hammer.exs
@@ -10,10 +10,11 @@ end
 
 defmodule Honeydew.Hammer do
 
-  @num_jobs 1_000_000
+  @num_jobs 1_000_00
 
   def run(func) do
-    :ok = Honeydew.start_queue(:queue)
+    # :ok = Honeydew.start_queue(:queue)
+    :ok = Honeydew.start_queue(:queue, queue: {Honeydew.Queue.Mnesia, [ram_copies: [node()]]})
     :ok = Honeydew.start_workers(:queue, Worker, num: 10)
 
     {microsecs, :ok} = :timer.tc(__MODULE__, func, [])
@@ -41,7 +42,8 @@ defmodule Honeydew.Hammer do
     Honeydew.async(fn -> send me, :done end, :queue)
 
     receive do
-      :done -> :ok
+      :done ->
+        :ok
     end
   end
 end

--- a/test/honeydew/failure_mode/exponential_retry_test.exs
+++ b/test/honeydew/failure_mode/exponential_retry_test.exs
@@ -1,0 +1,78 @@
+defmodule Honeydew.FailureMode.ExponentialRetryTest do
+  use ExUnit.Case, async: true
+
+  alias Honeydew.Queue.Mnesia
+
+  @moduletag :capture_log
+
+  setup do
+    queue = :erlang.unique_integer
+    failure_queue = "#{queue}_failed"
+
+    :ok = Honeydew.start_queue(queue, queue: {Mnesia, ram_copies: [node()]},
+                                      failure_mode: {Honeydew.FailureMode.ExponentialRetry,
+                                                     times: 3,
+                                                     finally: {Honeydew.FailureMode.Move, queue: failure_queue}})
+    :ok = Honeydew.start_queue(failure_queue, queue: {Mnesia, [ram_copies: [node()]]})
+    :ok = Honeydew.start_workers(queue, Stateless)
+
+    [queue: queue, failure_queue: failure_queue]
+  end
+
+  test "validate_args!/1" do
+    import Honeydew.FailureMode.ExponentialRetry, only: [validate_args!: 1]
+
+    assert :ok = validate_args!([times: 2])
+    assert :ok = validate_args!([times: 2, finally: {Honeydew.FailureMode.Move, [queue: :abc]}])
+
+    assert_raise ArgumentError, fn ->
+      validate_args!([base: -1])
+    end
+
+    assert_raise ArgumentError, fn ->
+      validate_args!(:abc)
+    end
+
+    assert_raise ArgumentError, fn ->
+      validate_args!([fun: fn _job, _reason -> :halt end])
+    end
+
+    assert_raise ArgumentError, fn ->
+      validate_args!([times: -1])
+    end
+
+    assert_raise ArgumentError, fn ->
+      validate_args!([times: 2, finally: {Honeydew.FailureMode.Move, [bad: :args]}])
+    end
+
+    assert_raise ArgumentError, fn ->
+      validate_args!([times: 2, finally: {"bad", []}])
+    end
+  end
+
+  test "should retry the job with exponentially increasing delays", %{queue: queue, failure_queue: failure_queue} do
+    {:crash, [self()]} |> Honeydew.async(queue)
+
+    delays =
+      Enum.map(0..3, fn _ ->
+        receive do
+          :job_ran ->
+            DateTime.utc_now()
+        end
+      end)
+      |> Enum.chunk_every(2, 1, :discard)
+      |> Enum.map(fn [a, b] -> DateTime.diff(b, a) end)
+
+    # 2^0 - 1 -> 0 sec delay
+    # 2^1 - 1 -> 1 sec delay
+    # 2^2 - 1 -> 3 sec delay
+    assert_in_delta Enum.at(delays, 0), 0, 1
+    assert_in_delta Enum.at(delays, 1), 1, 1
+    assert_in_delta Enum.at(delays, 2), 3, 1
+
+    assert Honeydew.status(queue) |> get_in([:queue, :count]) == 0
+    refute_receive :job_ran
+
+    assert Honeydew.status(failure_queue) |> get_in([:queue, :count]) == 1
+  end
+end

--- a/test/honeydew/failure_mode/retry_test.exs
+++ b/test/honeydew/failure_mode/retry_test.exs
@@ -1,15 +1,17 @@
 defmodule Honeydew.FailureMode.RetryTest do
   use ExUnit.Case, async: true
 
+  alias Honeydew.Queue.Mnesia
+
   @moduletag :capture_log
 
   setup do
     queue = :erlang.unique_integer
     failure_queue = "#{queue}_failed"
 
-    :ok = Honeydew.start_queue(queue, failure_mode: {Honeydew.FailureMode.Retry,
+    :ok = Honeydew.start_queue(queue, queue: {Mnesia, ram_copies: [node()]}, failure_mode: {Honeydew.FailureMode.Retry,
                                                      times: 3, finally: {Honeydew.FailureMode.Move, queue: failure_queue}})
-    :ok = Honeydew.start_queue(failure_queue)
+    :ok = Honeydew.start_queue(failure_queue, queue: {Mnesia, [ram_copies: [node()]]})
     :ok = Honeydew.start_workers(queue, Stateless)
 
     [queue: queue, failure_queue: failure_queue]

--- a/test/honeydew/queue/mnesia_queue_integration_test.exs
+++ b/test/honeydew/queue/mnesia_queue_integration_test.exs
@@ -214,8 +214,7 @@ defmodule Honeydew.MnesiaQueueIntegrationTest do
     :ok = Honeydew.stop_queue(queue)
     :ok = Honeydew.stop_workers(queue)
 
-    nodes = [node()]
-    :ok = Honeydew.start_queue(queue, queue: {Honeydew.Queue.Mnesia, [nodes, [disc_copies: nodes], []]})
+    :ok = start_queue(queue)
 
     %{queue: %{count: total, in_progress: in_progress}} = Honeydew.status(queue)
 
@@ -345,10 +344,9 @@ defmodule Honeydew.MnesiaQueueIntegrationTest do
   end
 
   defp start_queue(queue, opts \\ []) do
-    nodes = [node()]
     queue_opts =
       Keyword.merge(
-        [queue: {Honeydew.Queue.Mnesia, [nodes, [disc_copies: nodes], []]}],
+        [queue: {Honeydew.Queue.Mnesia, [disc_copies: [node()]]}],
         opts
       )
 

--- a/test/honeydew/queues_test.exs
+++ b/test/honeydew/queues_test.exs
@@ -3,7 +3,7 @@ defmodule Honeydew.QueuesTest do
   import Helper
   alias Honeydew.Queues
   alias Honeydew.Queue.State
-  alias Honeydew.Queue.{ErlangQueue, Mnesia}
+  alias Honeydew.Queue.Mnesia
   alias Honeydew.Dispatcher.{LRU, MRU}
   alias Honeydew.FailureMode.{Abandon, Retry}
   alias Honeydew.SuccessMode.Log
@@ -23,7 +23,7 @@ defmodule Honeydew.QueuesTest do
       nodes = [node()]
 
       options = [
-        queue: {Mnesia, [nodes, [disc_copies: nodes], []]},
+        queue: {Mnesia, [ram_copies: nodes]},
         dispatcher: {MRU, []},
         failure_mode: {Retry, [times: 5]},
         success_mode: {Log, []},
@@ -34,11 +34,11 @@ defmodule Honeydew.QueuesTest do
       assert [{{:global, :abc}, pid, _, _}] = Supervisor.which_children(Queues)
 
       assert %State{
-        dispatcher: {Honeydew.Dispatcher.MRU, _dispatcher_state},
-        failure_mode: {Honeydew.FailureMode.Retry, [times: 5]},
-        module: Honeydew.Queue.Mnesia,
+        dispatcher: {MRU, _dispatcher_state},
+        failure_mode: {Retry, [times: 5]},
+        module: Mnesia,
         queue: {:global, :abc},
-        success_mode: {Honeydew.SuccessMode.Log, []},
+        success_mode: {Log, []},
         suspended: true
       } = :sys.get_state(pid)
     end
@@ -60,7 +60,7 @@ defmodule Honeydew.QueuesTest do
       assert %State{
         dispatcher: {LRU, _dispatcher_state},
         failure_mode: {Abandon, []},
-        module: ErlangQueue,
+        module: Mnesia,
         queue: :abc,
         success_mode: nil,
         suspended: false


### PR DESCRIPTION
this PR introduces the concept of time into honeydew's API, specifically:
- adds the `delay_secs: <integer>` argument to `async/3`
- adds the `ExponentialRetry` failure mode
- generalizes the `Retry` failure mode to accept a user function to indicate the delay between retries
- generalizes the way jobs are stored in the Mnesia queue to allow for new features
- adds examples and documentation

I've moved the default queue to an in-memory Mnesia store, it's about half the raw speed of ErlangQueue (at 16k jobs/sec), but it supports the delay api. 

i'll get around to writing a priority queue implementation at some point for ErlangQueue if folks end up needing that kind of speed (probably a https://en.wikipedia.org/wiki/Fibonacci_heap). 

ref: https://github.com/koudelka/honeydew/issues/66