### PR TITLE
Fix bug in validate_args!/1

### DIFF
--- a/lib/honeydew/queue/mnesia.ex
+++ b/lib/honeydew/queue/mnesia.ex
@@ -30,7 +30,7 @@ defmodule Honeydew.Queue.Mnesia do
   @poll_interval 1_000
 
   @impl true
-  def validate_args!(opts) do
+  def validate_args!([_nodes, opts | _]) do
     nodes_list = nodes_list(opts)
 
     if Enum.empty?(nodes_list) do


### PR DESCRIPTION
Hi @koudelka,

Thanks for creating honeydew, it's been my go to job queue for all my elixir projects.

I'm having one problem with setting up a global queue following the example in [global](https://github.com/koudelka/honeydew/tree/master/examples/global).

```elixir
    :ok = Honeydew.start_queue({:global, :my_queue}, queue: {Honeydew.Queue.Mnesia, [[node()], [disc_copies: nodes], []]})
```

This always fails because `nodes_list/1` is trying to do `Keyword.get/3` on a list.