### PR TITLE
Fix documentation on the default queue for `start_queue`

### DIFF
--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -344,7 +344,7 @@ defmodule Honeydew do
   You can provide any of the following `opts`:
 
   - `queue`: is the module that queue will use. Defaults to
-    `Honeydew.Queue.ErlangQueue`. You may also provide args to the queue's
+    `Honeydew.Queue.Mnesia`. You may also provide args to the queue's
     `c:Honeydew.Queue.init/2` callback using the following format:
     `{module, args}`.
   - `dispatcher`: the job dispatching strategy, `{module, init_args}`.


### PR DESCRIPTION
See #105 

https://github.com/koudelka/honeydew/blob/1b07343e0d1df2b2819ca050b3d12c66d8b54cf0/lib/honeydew/queues.ex#L30-L36

The default queue is `Honeydew.Queue.Mnesia`. 