### PR TITLE
Fix compile warnings on Elixir 1.11

### DIFF
--- a/lib/honeydew/sources/ecto/sql.ex
+++ b/lib/honeydew/sources/ecto/sql.ex
@@ -46,8 +46,8 @@ defmodule Honeydew.EctoSource.SQL do
 
   defmacro ready_fragment(module) do
     quote do
-      unquote(module).ready
-      |> fragment
+      unquote(module).ready()
+      |> fragment()
     end
   end
 


### PR DESCRIPTION
I found warnings when I run `MIX_ENV=postgres mix ecto.migrate` in the the `ecto_poll_queue` example with Elixir 1.11.0:

```
warning: incompatible types:

    map() !~ atom()

in expression:

    # priv/repo/migrations/20180408023001_create_photos_and_users.exs:20
    sql_module.ready

where "sql_module" was given the type atom() (due to calling var.fun()) in:

    # priv/repo/migrations/20180408023001_create_photos_and_users.exs:20
    sql_module.integer_type()

where "sql_module" was given the type map() (due to calling var.field) in:

    # priv/repo/migrations/20180408023001_create_photos_and_users.exs:20
    sql_module.ready

HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

Conflict found at
  priv/repo/migrations/20180408023001_create_photos_and_users.exs:20: EctoPollQueueExample.Repo.Migrations.CreatePhotosAndUsers.change/0
```