### PR TITLE
Ignore {:reply, false} option for async request

### DIFF
--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -71,7 +71,10 @@ defmodule Honeydew do
       |> Enum.reduce(job, fn
         {:reply, true}, job ->
           %Job{job | from: {self(), make_ref()}}
-
+          
+        {:reply, false}, job ->
+          job
+          
         {:delay_secs, secs}, job when is_integer(secs) and secs >= 0 ->
           %Job{job | delay_secs: secs}
 


### PR DESCRIPTION
I was writing my own logic in front of honeydew and noticed that if I pass an option of `{reply: false}` into the `async/3` function it throws a function clause error as seen below:

`** (FunctionClauseError) no function clause matching in anonymous fn/2 in Honeydew.async/3`

I am of course able to write custom logic to call the function in another way without passing in `{:reply, false}` but I thought the function shouldn't error on a valid input entry given `reply` accepts a boolean option, my addition simply ignores it instead of throwing an error.

Also, Michael I have read your code in the honeydew project, you are an excellent programmer! Thanks for creating honeydew, it works fantastically, been using it in production for a year and it's holding strong!
