### PR TITLE
Fix compiler warnings

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :logger, :console,
   level: :info

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :logger,
   compile_time_purge_matching: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,8 +2,8 @@ import Config
 
 config :logger,
   compile_time_purge_matching: [
-    [level_lower_than: :warn]
+    [level_lower_than: :warning]
   ]
 
 config :logger, :console,
-  level: :warn
+  level: :warning

--- a/lib/honeydew.ex
+++ b/lib/honeydew.ex
@@ -108,8 +108,8 @@ defmodule Honeydew do
   """
   @spec yield(Job.t, timeout) :: {:ok, result} | nil | no_return
   def yield(job, timeout \\ 5000)
-  def yield(%Job{from: nil} = job, _), do: raise ArgumentError, reply_not_requested_error(job)
-  def yield(%Job{from: {owner, _}} = job, _) when owner != self(), do: raise ArgumentError, invalid_owner_error(job)
+  def yield(%Job{from: nil} = job, _), do: raise(ArgumentError, reply_not_requested_error(job))
+  def yield(%Job{from: {owner, _}} = job, _) when owner != self(), do: raise(ArgumentError, invalid_owner_error(job))
 
   def yield(%Job{from: {_, ref}}, timeout) do
     receive do

--- a/lib/honeydew/ecto_poll_queue.ex
+++ b/lib/honeydew/ecto_poll_queue.ex
@@ -63,11 +63,11 @@ defmodule Honeydew.EctoPollQueue do
 
   defp validate_stale_timeout!(interval) when is_integer(interval) and interval > 0, do: :ok
   defp validate_stale_timeout!(nil), do: :ok
-  defp validate_stale_timeout!(arg), do: raise ArgumentError, invalid_stale_timeout_error(arg)
+  defp validate_stale_timeout!(arg), do: raise(ArgumentError, invalid_stale_timeout_error(arg))
 
   defp validate_run_if!(sql) when is_binary(sql), do: :ok
   defp validate_run_if!(nil), do: :ok
-  defp validate_run_if!(arg), do: raise ArgumentError, invalid_run_if_error(arg)
+  defp validate_run_if!(arg), do: raise(ArgumentError, invalid_run_if_error(arg))
 
   defp invalid_stale_timeout_error(argument) do
     "Stale timeout must be an integer number of seconds. You gave #{inspect argument}"

--- a/lib/honeydew/failure_mode/abandon.ex
+++ b/lib/honeydew/failure_mode/abandon.ex
@@ -18,11 +18,11 @@ defmodule Honeydew.FailureMode.Abandon do
 
   @impl true
   def validate_args!([]), do: :ok
-  def validate_args!(args), do: raise ArgumentError, "You provided arguments (#{inspect args}) to the Abandon failure mode, it only accepts an empty list"
+  def validate_args!(args), do: raise(ArgumentError, "You provided arguments (#{inspect args}) to the Abandon failure mode, it only accepts an empty list")
 
   @impl true
   def handle_failure(%Job{queue: queue, from: from} = job, reason, []) do
-    Logger.warn "Job failed because #{inspect reason}, abandoning: #{inspect job}"
+    Logger.warning "Job failed because #{inspect reason}, abandoning: #{inspect job}"
 
     # tell the queue that that job can be removed.
     queue

--- a/lib/honeydew/failure_mode/move.ex
+++ b/lib/honeydew/failure_mode/move.ex
@@ -23,7 +23,7 @@ defmodule Honeydew.FailureMode.Move do
   @impl true
   def validate_args!([queue: {:global, queue}]) when is_atom(queue) or is_binary(queue), do: :ok
   def validate_args!([queue: queue]), do: validate_args!(queue: {:global, queue})
-  def validate_args!(args), do: raise ArgumentError, "You provided arguments (#{inspect args}) to the Move failure mode, it's expecting [queue: to_queue]"
+  def validate_args!(args), do: raise(ArgumentError, "You provided arguments (#{inspect args}) to the Move failure mode, it's expecting [queue: to_queue]")
 
   @impl true
   def handle_failure(%Job{queue: queue, from: from} = job, reason, [queue: to_queue]) do

--- a/lib/honeydew/job_monitor.ex
+++ b/lib/honeydew/job_monitor.ex
@@ -102,7 +102,7 @@ defmodule Honeydew.JobMonitor do
   end
 
   def handle_info(msg, state) do
-    Logger.warn "[Honeydew] Monitor #{inspect self()} received unexpected message #{inspect msg}"
+    Logger.warning "[Honeydew] Monitor #{inspect self()} received unexpected message #{inspect msg}"
     {:noreply, state}
   end
 

--- a/lib/honeydew/logger.ex
+++ b/lib/honeydew/logger.ex
@@ -8,7 +8,7 @@ defmodule Honeydew.Logger do
   require Logger
 
   def worker_init_crashed(module, %Crash{type: :exception, reason: exception} = crash) do
-    Logger.warn(fn ->
+    Logger.warning(fn ->
       {
         "#{module}.init/1 must return {:ok, state :: any()}, but raised #{inspect(exception)}",
         honeydew_crash_reason: Metadata.build_crash_reason(crash)
@@ -17,7 +17,7 @@ defmodule Honeydew.Logger do
   end
 
   def worker_init_crashed(module, %Crash{type: :throw, reason: thrown} = crash) do
-    Logger.warn(fn ->
+    Logger.warning(fn ->
       {
         "#{module}.init/1 must return {:ok, state :: any()}, but threw #{inspect(thrown)}",
         honeydew_crash_reason: Metadata.build_crash_reason(crash)
@@ -26,7 +26,7 @@ defmodule Honeydew.Logger do
   end
 
   def worker_init_crashed(module, %Crash{type: :bad_return_value, reason: value} = crash) do
-    Logger.warn(fn ->
+    Logger.warning(fn ->
       {
         "#{module}.init/1 must return {:ok, state :: any()}, got: #{inspect value}",
         honeydew_crash_reason: Metadata.build_crash_reason(crash)
@@ -35,7 +35,7 @@ defmodule Honeydew.Logger do
   end
 
   def job_failed(%Job{} = job, %Crash{type: :exception} = crash) do
-    Logger.warn(fn ->
+    Logger.warning(fn ->
       {
         """
         Job failed due to exception. #{inspect(job)}
@@ -48,7 +48,7 @@ defmodule Honeydew.Logger do
   end
 
   def job_failed(%Job{} = job, %Crash{type: :throw} = crash) do
-    Logger.warn(fn ->
+    Logger.warning(fn ->
       {
         """
         Job failed due to uncaught throw. #{inspect job}",
@@ -61,7 +61,7 @@ defmodule Honeydew.Logger do
   end
 
   def job_failed(%Job{} = job, %Crash{type: :exit} = crash) do
-    Logger.warn(fn ->
+    Logger.warning(fn ->
       {
         """
         Job failed due unexpected exit. #{inspect job}",

--- a/lib/honeydew/node_monitor.ex
+++ b/lib/honeydew/node_monitor.ex
@@ -36,7 +36,7 @@ defmodule Honeydew.NodeMonitor do
   def handle_info({:nodeup, _}, node), do: {:noreply, node}
 
   def handle_info({:nodedown, node}, node) do
-    Logger.warn "[Honeydew] Lost connection to #{node}, attempting to reestablish..."
+    Logger.warning "[Honeydew] Lost connection to #{node}, attempting to reestablish..."
 
     GenServer.cast(self(), :ping)
 

--- a/lib/honeydew/poll_queue.ex
+++ b/lib/honeydew/poll_queue.ex
@@ -40,7 +40,7 @@ defmodule Honeydew.PollQueue do
 
   defp validate_poll_interval!(interval) when is_integer(interval) and interval > 0, do: :ok
   defp validate_poll_interval!(nil), do: :ok
-  defp validate_poll_interval!(arg), do: raise ArgumentError, invalid_poll_interval_error(arg)
+  defp validate_poll_interval!(arg), do: raise(ArgumentError, invalid_poll_interval_error(arg))
 
   defp invalid_poll_interval_error(argument) do
     "Poll interval must be positive integer number of seconds. You gave #{inspect argument}"

--- a/lib/honeydew/queue.ex
+++ b/lib/honeydew/queue.ex
@@ -190,7 +190,7 @@ defmodule Honeydew.Queue do
   end
 
   def node_down(node) do
-    Logger.warn "[Honeydew] Lost connection to #{node}."
+    Logger.warning "[Honeydew] Lost connection to #{node}."
   end
 
   def worker_stopped(worker, state) do
@@ -199,7 +199,7 @@ defmodule Honeydew.Queue do
   end
 
   def worker_crashed(worker, reason, state) do
-    Logger.warn "[Honeydew] Queue #{inspect self()} saw worker #{inspect worker} crash because #{inspect reason}"
+    Logger.warning "[Honeydew] Queue #{inspect self()} saw worker #{inspect worker} crash because #{inspect reason}"
     remove_worker(state, worker)
   end
 
@@ -213,7 +213,7 @@ defmodule Honeydew.Queue do
 
   def job_monitor_crashed(job_monitor, reason, %State{job_monitors: job_monitors} = state) do
     {job, job_monitors} = Map.pop(job_monitors, job_monitor)
-    Logger.warn "[Honeydew] Job Monitor #{inspect job_monitor} crashed, this really should never happen, is there a bug in the success/failure mode module? Reason: #{inspect reason} Job: #{inspect job}"
+    Logger.warning "[Honeydew] Job Monitor #{inspect job_monitor} crashed, this really should never happen, is there a bug in the success/failure mode module? Reason: #{inspect reason} Job: #{inspect job}"
     %{state | job_monitors: job_monitors}
   end
 
@@ -280,7 +280,7 @@ defmodule Honeydew.Queue do
     |> if do
       module.handle_info(msg, state)
     else
-      Logger.warn "[Honeydew] Queue #{inspect queue} (#{inspect self()}) received unexpected message #{inspect msg}"
+      Logger.warning "[Honeydew] Queue #{inspect queue} (#{inspect self()}) received unexpected message #{inspect msg}"
       {:noreply, state}
     end
   end
@@ -297,7 +297,7 @@ defmodule Honeydew.Queue do
         :worker -> worker_stopped(process, state)
         :job_monitor -> job_monitor_stopped(process, state)
         :unknown ->
-          Logger.warn "[Honeydew] Received non-crash EXIT/DOWN message for unknown process #{inspect process}"
+          Logger.warning "[Honeydew] Received non-crash EXIT/DOWN message for unknown process #{inspect process}"
           state
       end
     {:noreply, state}
@@ -309,7 +309,7 @@ defmodule Honeydew.Queue do
         :worker -> worker_crashed(process, reason, state)
         :job_monitor -> job_monitor_crashed(process, reason, state)
         :unknown ->
-          Logger.warn "[Honeydew] Received EXIT/DOWN message for unknown process #{inspect process}, reason: #{inspect reason}"
+          Logger.warning "[Honeydew] Received EXIT/DOWN message for unknown process #{inspect process}, reason: #{inspect reason}"
           state
       end
     {:noreply, state}

--- a/lib/honeydew/queue/erlang_queue.ex
+++ b/lib/honeydew/queue/erlang_queue.ex
@@ -12,7 +12,7 @@ defmodule Honeydew.Queue.ErlangQueue do
 
   @impl true
   def validate_args!([]), do: :ok
-  def validate_args!(args), do: raise ArgumentError, "You provided arguments (#{inspect args}) to the #{__MODULE__} queue, it's expecting an empty list, or just the bare module."
+  def validate_args!(args), do: raise(ArgumentError, "You provided arguments (#{inspect args}) to the #{__MODULE__} queue, it's expecting an empty list, or just the bare module.")
 
   @impl true
   def init(_name, []) do

--- a/lib/honeydew/queue/mnesia.ex
+++ b/lib/honeydew/queue/mnesia.ex
@@ -327,7 +327,7 @@ defmodule Honeydew.Queue.Mnesia do
 
   defp time_warp_mode_warning do
     if :erlang.system_info(:time_warp_mode) != :multi_time_warp do
-      Logger.warn "[Honeydew] It's recommended to use the Mnesia queue with the 'multi_time_warp' time correction mode to minimize montonic clock freezes, see http://erlang.org/doc/apps/erts/time_correction.html#multi-time-warp-mode."
+      Logger.warning "[Honeydew] It's recommended to use the Mnesia queue with the 'multi_time_warp' time correction mode to minimize montonic clock freezes, see http://erlang.org/doc/apps/erts/time_correction.html#multi-time-warp-mode."
     end
   end
 end

--- a/lib/honeydew/queue_monitor.ex
+++ b/lib/honeydew/queue_monitor.ex
@@ -29,7 +29,7 @@ defmodule Honeydew.QueueMonitor do
   end
 
   def handle_info(msg, state) do
-    Logger.warn "[QueueMonitor] Received unexpected message #{inspect msg}"
+    Logger.warning "[QueueMonitor] Received unexpected message #{inspect msg}"
     {:noreply, state}
   end
 end

--- a/lib/honeydew/sources/ecto_source.ex
+++ b/lib/honeydew/sources/ecto_source.ex
@@ -127,7 +127,7 @@ if Code.ensure_loaded?(Ecto) do
           {:empty, state}
 
         {:error, error} ->
-          Logger.warn("[Honeydew] Ecto queue '#{inspect queue}' couldn't poll for jobs because #{inspect error}")
+          Logger.warning("[Honeydew] Ecto queue '#{inspect queue}' couldn't poll for jobs because #{inspect error}")
           {:empty, state}
       end
     end
@@ -220,7 +220,7 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     def handle_info(msg, queue_state) do
-      Logger.warn("[Honeydew] Queue #{inspect(self())} received unexpected message #{inspect(msg)}")
+      Logger.warning("[Honeydew] Queue #{inspect(self())} received unexpected message #{inspect(msg)}")
 
       {:noreply, queue_state}
     end

--- a/lib/honeydew/success_mode/log.ex
+++ b/lib/honeydew/success_mode/log.ex
@@ -17,7 +17,7 @@ defmodule Honeydew.SuccessMode.Log do
 
   @impl true
   def validate_args!([]), do: :ok
-  def validate_args!(args), do: raise ArgumentError, "You provided arguments (#{inspect args}) to the Log success mode, it only accepts an empty list"
+  def validate_args!(args), do: raise(ArgumentError, "You provided arguments (#{inspect args}) to the Log success mode, it only accepts an empty list")
 
   @impl true
   def handle_success(%Job{enqueued_at: enqueued_at, started_at: started_at, completed_at: completed_at, result: {:ok, result}} = job, []) do

--- a/lib/honeydew/worker.ex
+++ b/lib/honeydew/worker.ex
@@ -207,7 +207,7 @@ defmodule Honeydew.Worker do
   @impl true
   @doc false
   def handle_info({:EXIT, queue_pid, _reason}, %State{queue: queue, queue_pid: queue_pid} = state) do
-    Logger.warn "[Honeydew] Worker #{inspect queue} (#{inspect self()}) saw its queue die, stopping..."
+    Logger.warning "[Honeydew] Worker #{inspect queue} (#{inspect self()}) saw its queue die, stopping..."
     {:noreply, state}
   end
 
@@ -216,13 +216,13 @@ defmodule Honeydew.Worker do
   def handle_info({:EXIT, _pid, {:shutdown, _}}, %State{job_runner: nil} = state), do: {:noreply, state}
 
   def handle_info({:EXIT, job_runner, reason}, %State{job_runner: job_runner, queue: queue, job: job} = state) do
-    Logger.warn "[Honeydew] Worker #{inspect queue} (#{inspect self()}) saw its job runner (#{inspect job_runner}) die during a job, restarting..."
+    Logger.warning "[Honeydew] Worker #{inspect queue} (#{inspect self()}) saw its job runner (#{inspect job_runner}) die during a job, restarting..."
     job = %{job | result: {:error, Crash.new(:exit, reason)}}
     {:noreply, state, {:continue, {:job_finished, job}}}
   end
 
   def handle_info(msg, %State{queue: queue} = state) do
-    Logger.warn "[Honeydew] Worker #{inspect queue} (#{inspect self()}) received unexpected message #{inspect msg}, restarting..."
+    Logger.warning "[Honeydew] Worker #{inspect queue} (#{inspect self()}) received unexpected message #{inspect msg}, restarting..."
     restart(state)
   end
 


### PR DESCRIPTION
Logger.warn has been deprecated in favour of Logger.warning

use Mix.Config has been deprecated in favour of import Config

The compiler warned about missing parentheses inside keywords, this has also been fixed here.

Maybe we can also update the elixir and erlang version in .tools-version and update the compatible elixir version in mix.exs?